### PR TITLE
Simple fix for the white tab bar on the top of the window

### DIFF
--- a/main.js
+++ b/main.js
@@ -25,6 +25,7 @@ app.commandLine.appendSwitch("--enable-features", "Metal");
 
 function createWindow() {
 	win = new BrowserWindow({
+		autoHideMenuBar: true,
 		show: false,
 		icon: __dirname + "/assets/images/icon.png",
 		spellcheck: false,


### PR DESCRIPTION
![image](https://github.com/aandrew-me/ytDownloader/assets/72302817/974feb36-572b-46ef-95ce-abb199f4ce84)

it remove that white bar on top, i just copied the fix from [here](https://stackoverflow.com/questions/39091964/remove-menubar-from-electron-app), i could only test on the linux version