### PR TITLE
Security: Command injection via unsanitized clipboard URL in shell command

### DIFF
--- a/src/playlist_new.js
+++ b/src/playlist_new.js
@@ -3,7 +3,7 @@ const { default: YTDlpWrap } = require("yt-dlp-wrap-plus");
 const path = require("path");
 const os = require("os");
 const fs = require("fs");
-const { execSync, exec, spawnSync } = require("child_process");
+const { execSync, execFile, spawnSync } = require("child_process");
 let url;
 const ytDlp = localStorage.getItem("ytdlp");
 const ytdlp = new YTDlpWrap(ytDlp);
@@ -59,8 +59,35 @@ function pasteLink() {
 	getId("errorBtn").style.display = "none";
 	getId("errorDetails").style.display = "none";
 	getId("errorDetails").textContent = "";
-	exec(
-		`${ytDlp} --yes-playlist --no-warnings -J --flat-playlist "${clipboardText}"`,
+	let clipboardUrl;
+	try {
+		clipboardUrl = new URL(clipboardText);
+		if (clipboardUrl.protocol !== "http:" && clipboardUrl.protocol !== "https:") {
+			throw new Error("Invalid URL protocol");
+		}
+	} catch (error) {
+		getId("loadingWrapper").style.display = "none";
+		getId("incorrectMsg").textContent = i18n.__(
+			"Incompatible URL. Please provide a playlist URL"
+		);
+		getId("errorDetails").innerHTML = `
+			<strong>URL: ${clipboardText}</strong>
+			<br><br>
+			${error}
+			`;
+		getId("errorDetails").title = i18n.__("Click to copy");
+		getId("errorBtn").style.display = "inline-block";
+		return;
+	}
+	execFile(
+		ytDlp,
+		[
+			"--yes-playlist",
+			"--no-warnings",
+			"-J",
+			"--flat-playlist",
+			clipboardUrl.toString(),
+		],
 		(error, stdout, stderr) => {
 			if (error) {
 				getId("loadingWrapper").style.display = "none";
@@ -116,7 +143,7 @@ function pasteLink() {
 					getId("errorDetails").innerHTML = `
 			<strong>URL: ${clipboardText}</strong>
 			<br><br>
-			${error}
+			${stderr}
 			`;
 					getId("errorDetails").title = i18n.__("Click to copy");
 					getId("errorBtn").style.display = "inline-block";


### PR DESCRIPTION
## Problem

The playlist URL from clipboard is interpolated directly into a shell command passed to `exec(...)`. An attacker can craft clipboard content containing quotes/shell metacharacters to break out of the quoted argument and execute arbitrary commands.

**Severity**: `critical`
**File**: `src/playlist_new.js`

## Solution

Do not build shell strings with untrusted input. Use `spawn`/`execFile` with an argument array (no shell), e.g. `spawn(ytDlpPath, ['--yes-playlist','--no-warnings','-J','--flat-playlist', clipboardText])`. Also validate URL format before execution.

## Changes

- `src/playlist_new.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added client-side URL validation to reject incompatible URLs with a clear "Incompatible URL" message.
  * Improved error reporting to display detailed error messages instead of generic error objects, making troubleshooting easier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->