### PR TITLE
feat(compressor): overhaul UX with quality presets, target size/% modes

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1392,3 +1392,235 @@ input[type="range"]::-webkit-slider-thumb:hover {
 	color: var(--text) !important;
 	opacity: 0.8;
 }
+
+/* New Compressor UX Styles */
+.quality-presets {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 12px;
+	margin-bottom: 15px;
+	width: 100%;
+}
+
+.preset-btn {
+	flex: 1;
+	min-width: 130px;
+	background-color: var(--box-toggle);
+	border: 1px solid var(--box-separation);
+	color: var(--text);
+	padding: 12px 14px;
+	border-radius: 12px;
+	cursor: pointer;
+	text-align: center;
+	transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.preset-btn:hover {
+	transform: translateY(-2px);
+	background-color: var(--box-separation);
+	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+	border-color: var(--blueBtn);
+}
+
+.preset-btn.active {
+	background: var(--blueBtn);
+	border-color: var(--blueBtn-bottom);
+	color: #ffffff;
+	box-shadow: 0 4px 10px rgba(59, 130, 246, 0.3);
+}
+
+.preset-btn.active .preset-desc {
+	color: rgba(255, 255, 255, 0.8);
+}
+
+.preset-title {
+	font-size: 14px;
+	font-weight: 700;
+	display: block;
+}
+
+.preset-desc {
+	font-size: 11px;
+	opacity: 0.7;
+	display: block;
+	margin-top: 4px;
+	transition: color 0.2s;
+}
+
+.custom-slider-container, .target-size-container, .target-percent-container {
+	background-color: var(--box-toggle);
+	border: 1px solid var(--box-separation);
+	padding: 18px 24px;
+	border-radius: 12px;
+	margin-top: 15px;
+	width: 100%;
+	box-sizing: border-box;
+	animation: slideDown 0.3s ease;
+}
+
+@keyframes slideDown {
+	from {
+		opacity: 0;
+		transform: translateY(-10px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+.slider-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 12px;
+}
+
+.crf-value-label {
+	font-size: 15px;
+	font-weight: 700;
+	color: var(--text);
+}
+
+.crf-description {
+	font-size: 13px;
+	color: var(--text);
+	opacity: 0.85;
+}
+
+.slider-wrapper {
+	display: flex;
+	align-items: center;
+	gap: 15px;
+	width: 100%;
+}
+
+.slider-extremes {
+	font-size: 11px;
+	opacity: 0.6;
+	font-weight: 600;
+	text-transform: uppercase;
+	min-width: 40px;
+}
+
+#quality-slider {
+	position: relative !important;
+	pointer-events: auto !important;
+	-webkit-appearance: none;
+	appearance: none;
+	width: 100%;
+	height: 6px;
+	border-radius: 10px;
+	background: #4b5563 !important;
+	outline: none;
+	margin: 0;
+	padding: 0;
+}
+
+#quality-slider::-webkit-slider-runnable-track {
+	width: 100%;
+	height: 6px;
+	cursor: pointer;
+	background: #4b5563 !important;
+	border-radius: 10px;
+}
+
+#quality-slider::-webkit-slider-thumb {
+	-webkit-appearance: none;
+	appearance: none;
+	width: 18px;
+	height: 18px;
+	border-radius: 50%;
+	background: var(--blueBtn);
+	cursor: pointer;
+	margin-top: -6px;
+	transition: transform 0.15s, background-color 0.15s;
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+#quality-slider::-webkit-slider-thumb:hover {
+	transform: scale(1.25);
+	background: var(--blueBtn-bottom);
+}
+
+.target-size-container, .target-percent-container {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 8px;
+}
+
+#target-size-input, #target-percent-input {
+	background-color: var(--select);
+	color: var(--text);
+	border: 1px solid var(--box-separation);
+	padding: 10px 14px;
+	border-radius: 8px;
+	font-size: 15px;
+	outline: none;
+	width: 120px;
+	transition: border-color 0.2s;
+}
+
+#target-size-input:focus, #target-percent-input:focus {
+	border-color: var(--blueBtn);
+}
+
+.advanced-toggle-btn {
+	background-color: var(--box-toggle);
+	border: 1px solid var(--box-separation);
+	color: var(--text);
+	padding: 10px 20px;
+	border-radius: 10px;
+	font-size: 14px;
+	font-weight: 600;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	margin: 25px auto 15px auto;
+	transition: background-color 0.2s, transform 0.1s;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.advanced-toggle-btn:hover {
+	background-color: var(--box-separation);
+}
+
+.advanced-toggle-btn:active {
+	transform: scale(0.98);
+}
+
+.advanced-toggle-btn .toggle-icon {
+	display: inline-block;
+	transition: transform 0.3s ease;
+	font-size: 12px;
+}
+
+.advanced-toggle-btn.expanded .toggle-icon {
+	transform: rotate(90deg);
+}
+
+.advanced-settings-collapse {
+	overflow: hidden;
+	max-height: 1000px;
+	opacity: 1;
+	transition: max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease;
+}
+
+.advanced-settings-collapse.collapsed {
+	max-height: 0 !important;
+	opacity: 0 !important;
+	pointer-events: none;
+}
+
+.full-width-settings {
+	width: 100% !important;
+}
+

--- a/html/compressor.html
+++ b/html/compressor.html
@@ -48,101 +48,127 @@
             <div id="selected-files" data-translate="noFilesSelected">No files selected</div>
         </div>
 
-        <div id="settings-group-container">
-            <div class="settings-group">
-                <label class="compress-label" for="extension" data-translate="videoFormat">Video format</label>
-                <select class="select compress-select" id="file_extension">
-                    <option value="unchanged">Unchanged</option>
-                    <option value="mp4">mp4</option>
-                    <option value="mkv">mkv</option>
-                </select>
+        <!-- Main Quality Setting (Always Visible) -->
+        <div class="main-quality-container">
+            <input type="hidden" id="video-quality" value="balanced">
+            <div class="settings-group full-width-settings">
+                <label class="compress-label" data-translate="videoQuality">Video Quality</label>
+                <div class="quality-presets">
+                    <button type="button" class="preset-btn" data-quality="small">
+                        <span class="preset-title" data-translate="qualitySmallFile">Small File</span>
+                        <span class="preset-desc" data-translate="qualitySmallFileDesc">Decent quality, smaller size</span>
+                    </button>
+                    <button type="button" class="preset-btn active" data-quality="balanced">
+                        <span class="preset-title" data-translate="qualityBalanced">Balanced</span>
+                        <span class="preset-desc" data-translate="qualityBalancedDesc">Recommended</span>
+                    </button>
+                    <button type="button" class="preset-btn" data-quality="high">
+                        <span class="preset-title" data-translate="qualityHigh">High Quality</span>
+                        <span class="preset-desc" data-translate="qualityHighDesc">Excellent detail, larger size</span>
+                    </button>
+                    <button type="button" class="preset-btn" id="custom-quality-btn" data-quality="custom">
+                        <span class="preset-title" data-translate="qualityCustom">Custom</span>
+                        <span class="preset-desc" data-translate="qualityCustomDesc">Choose exact CRF</span>
+                    </button>
+                    <button type="button" class="preset-btn" id="target-size-btn" data-quality="target-size">
+                        <span class="preset-title" data-translate="qualityTargetSize">Target Size</span>
+                        <span class="preset-desc" data-translate="qualityTargetSizeDesc">Specify target MB</span>
+                    </button>
+                    <button type="button" class="preset-btn" id="target-percent-btn" data-quality="target-percent">
+                        <span class="preset-title" data-translate="qualityTargetPercent">Target %</span>
+                        <span class="preset-desc" data-translate="qualityTargetPercentDesc">Compress to % of size</span>
+                    </button>
+                </div>
+
+                <!-- Custom Quality Slider Container -->
+                <div id="custom-quality-container" class="custom-slider-container" style="display: none;">
+                    <div class="slider-header">
+                        <span class="crf-value-label">CRF: <span id="crf-val">23</span></span>
+                        <span class="crf-description" id="crf-desc" data-translate="qualityBalancedDesc">Recommended</span>
+                    </div>
+                    <div class="slider-wrapper">
+                        <span class="slider-extremes" data-translate="worst">Worst</span>
+                        <input type="range" id="quality-slider" min="18" max="51" step="1" value="46">
+                        <span class="slider-extremes" data-translate="best">Best</span>
+                    </div>
+                </div>
+
+                <!-- Target Size Container -->
+                <div id="target-size-container" class="target-size-container" style="display: none;">
+                    <label class="compress-label" for="target-size-input" data-translate="targetSizeMB">Target Size (MB)</label>
+                    <input type="number" id="target-size-input" class="select compress-select" min="1" max="10000" value="25" placeholder="e.g. 25">
+                </div>
+
+                <!-- Target Percentage Container -->
+                <div id="target-percent-container" class="target-percent-container" style="display: none;">
+                    <label class="compress-label" for="target-percent-input" data-translate="targetPercentLabel">Target Percentage (%)</label>
+                    <input type="number" id="target-percent-input" class="select compress-select" min="1" max="99" value="50" placeholder="e.g. 50">
+                </div>
             </div>
+        </div>
 
-            <div class="settings-group">
-                <label class="compress-label" for="encoder" data-translate="videoEncoder">Video Encoder</label>
-                <select class="select compress-select" id="encoder">
-                    <option value="x264">x264</option>
-                    <option value="x265">x265</option>
-                    <option class="qsv_opt" value="qsv">x264 (Intel QSV Hardware Acceleration)</option>
-                    <option class="qsv_opt" value="hevc_qsv">x265 (Intel QSV Hardware Acceleration)</option>
-                    <option class="amf_opt" value="amf">x264 (AMD Hardware Acceleration)</option>
-                    <option class="amf_opt" value="hevc_amf">x265 (AMD Hardware Acceleration)</option>
-                    <option class="nvidia_opt" value="nvenc">x264 (NVIDIA Hardware Acceleration)</option>
-                    <option class="nvidia_opt" value="hevc_nvenc">x265 (NVIDIA Hardware Acceleration)</option>
-                    <option class="vaapi_opt" value="vaapi">x264 (VA-API Hardware Acceleration)</option>
-                    <option class="vaapi_opt" value="hevc_vaapi">x265 (VA-API Hardware Acceleration)</option>
-                    <option class="videotoolbox_opt" value="videotoolbox">x264 (VideoToolbox Hardware Acceleration)
-                    </option>
-                    <option class="videotoolbox_opt" value="hevc_videotoolbox">x265 (VideoToolbox Hardware Acceleration)
-                    </option>
-                    <option value="copy">Copy video</option>
-                </select>
-            </div>
+        <!-- Advanced Toggle -->
+        <button type="button" class="advanced-toggle-btn" id="advanced-toggle-btn">
+            <span class="toggle-icon">▸</span> <span data-translate="advancedSettings">Advanced Settings</span>
+        </button>
 
-            <div class="settings-group">
-                <label class="compress-label" for="compression-speed" data-translate="compressionSpeed">Compression
-                    Speed</label>
-                <select class="select compress-select" id="compression-speed">
-                    <option value="fast">Fast</option>
-                    <option selected value="medium">Medium</option>
-                    <option value="slow">Slow</option>
-                </select>
-            </div>
+        <!-- Collapsible Advanced Settings -->
+        <div id="advanced-settings-collapse" class="advanced-settings-collapse collapsed">
+            <div id="settings-group-container">
+                <div class="settings-group">
+                    <label class="compress-label" for="extension" data-translate="videoFormat">Video format</label>
+                    <select class="select compress-select" id="file_extension">
+                        <option value="unchanged">Unchanged</option>
+                        <option value="mp4">mp4</option>
+                        <option value="mkv">mkv</option>
+                    </select>
+                </div>
 
-            <div class="settings-group">
-                <label class="compress-label" for="video-quality" data-translate="videoQuality">Video Quality</label>
-                <select class="select compress-select" id="video-quality">
-                    <option value="18">18 (Best quality)</option>
-                    <option value="19">19</option>
-                    <option value="20">20</option>
-                    <option value="21">21</option>
-                    <option value="22">22</option>
-                    <option selected value="23">23 (Medium size, good quality)</option>
-                    <option value="24">24</option>
-                    <option value="25">25</option>
-                    <option value="26">26</option>
-                    <option value="27">27</option>
-                    <option value="28">28 (Smaller file size, decent quality)</option>
-                    <option value="29">29</option>
-                    <option value="30">30</option>
-                    <option value="31">31</option>
-                    <option value="32">32</option>
-                    <option value="33">33</option>
-                    <option value="34">34</option>
-                    <option value="35">35</option>
-                    <option value="36">36</option>
-                    <option value="37">37</option>
-                    <option value="38">38</option>
-                    <option value="39">39</option>
-                    <option value="40">40</option>
-                    <option value="41">41</option>
-                    <option value="42">42</option>
-                    <option value="43">43</option>
-                    <option value="44">44</option>
-                    <option value="45">45</option>
-                    <option value="46">46</option>
-                    <option value="47">47</option>
-                    <option value="48">48</option>
-                    <option value="49">49</option>
-                    <option value="50">50</option>
-                    <option value="51">51 (Worst quality)</option>
-                </select>
+                <div class="settings-group">
+                    <label class="compress-label" for="encoder" data-translate="videoEncoder">Video Encoder</label>
+                    <select class="select compress-select" id="encoder">
+                        <option value="x264">x264</option>
+                        <option value="x265">x265</option>
+                        <option class="qsv_opt" value="qsv">x264 (Intel QSV Hardware Acceleration)</option>
+                        <option class="qsv_opt" value="hevc_qsv">x265 (Intel QSV Hardware Acceleration)</option>
+                        <option class="amf_opt" value="amf">x264 (AMD Hardware Acceleration)</option>
+                        <option class="amf_opt" value="hevc_amf">x265 (AMD Hardware Acceleration)</option>
+                        <option class="nvidia_opt" value="nvenc">x264 (NVIDIA Hardware Acceleration)</option>
+                        <option class="nvidia_opt" value="hevc_nvenc">x265 (NVIDIA Hardware Acceleration)</option>
+                        <option class="vaapi_opt" value="vaapi">x264 (VA-API Hardware Acceleration)</option>
+                        <option class="vaapi_opt" value="hevc_vaapi">x265 (VA-API Hardware Acceleration)</option>
+                        <option class="videotoolbox_opt" value="videotoolbox">x264 (VideoToolbox Hardware Acceleration)
+                        </option>
+                        <option class="videotoolbox_opt" value="hevc_videotoolbox">x265 (VideoToolbox Hardware Acceleration)
+                        </option>
+                        <option value="copy">Copy video</option>
+                    </select>
+                </div>
 
-            </div>
+                <div class="settings-group">
+                    <label class="compress-label" for="compression-speed" data-translate="compressionSpeed">Compression
+                        Speed</label>
+                    <select class="select compress-select" id="compression-speed">
+                        <option value="fast">Fast</option>
+                        <option selected value="medium">Medium</option>
+                        <option value="slow">Slow</option>
+                    </select>
+                </div>
 
-            <div class="settings-group">
-                <label class="compress-label" for="audio-format" data-translate="audioFormat">Audio Format</label>
-                <select class="select compress-select" id="audio-format">
-                    <option value="copy">Unchanged</option>
-                    <option value="aac">aac</option>
-                    <option value="mp3">mp3</option>
-                </select>
-            </div>
+                <div class="settings-group">
+                    <label class="compress-label" for="audio-format" data-translate="audioFormat">Audio Format</label>
+                    <select class="select compress-select" id="audio-format">
+                        <option value="copy">Unchanged</option>
+                        <option value="aac">aac</option>
+                        <option value="mp3">mp3</option>
+                    </select>
+                </div>
 
-            <div class="settings-group">
-                <div class="compress-label" data-translate="outputSuffix">Output suffix</div>
-                <input type="text" name="suffix" id="output-suffix" class="select compress-select"
-                    placeholder="No suffix needs different output folder" value="_compressed">
+                <div class="settings-group">
+                    <div class="compress-label" data-translate="outputSuffix">Output suffix</div>
+                    <input type="text" name="suffix" id="output-suffix" class="select compress-select"
+                        placeholder="No suffix needs different output folder" value="_compressed">
+                </div>
             </div>
         </div>
 

--- a/src/compressor.js
+++ b/src/compressor.js
@@ -42,6 +42,14 @@ const dom = {
 	audioFormat: getId("audio-format"),
 	fileExtension: getId("file_extension"),
 	outputSuffix: getId("output-suffix"),
+	targetSizeInput: getId("target-size-input"),
+	qualitySlider: getId("quality-slider"),
+	customQualityContainer: getId("custom-quality-container"),
+	targetSizeContainer: getId("target-size-container"),
+	targetPercentInput: getId("target-percent-input"),
+	targetPercentContainer: getId("target-percent-container"),
+	advancedToggleBtn: getId("advanced-toggle-btn"),
+	advancedSettingsCollapse: getId("advanced-settings-collapse"),
 };
 
 function openMenu() {
@@ -260,7 +268,7 @@ function generateOutputPath(file, settings) {
  * @param {string} outputPath
  */
 async function compressVideo(file, settings, itemId, outputPath) {
-	const args = buildFFmpegArgs(file, settings, outputPath);
+	const args = await buildFFmpegArgs(file, settings, outputPath);
 	console.log("Command: " + args.join(" "));
 
 	return new Promise((resolve, reject) => {
@@ -323,17 +331,105 @@ async function compressVideo(file, settings, itemId, outputPath) {
 	});
 }
 
+function getCRFValue(settings) {
+	const isHEVC =
+		settings.encoder === "x265" ||
+		settings.encoder === "hevc_qsv" ||
+		settings.encoder === "hevc_amf" ||
+		settings.encoder === "hevc_nvenc" ||
+		settings.encoder === "hevc_vaapi" ||
+		settings.encoder === "hevc_videotoolbox";
+
+	if (settings.videoQuality === "small") {
+		return isHEVC ? "32" : "28";
+	}
+	if (settings.videoQuality === "balanced") {
+		return isHEVC ? "28" : "23";
+	}
+	if (settings.videoQuality === "high") {
+		return isHEVC ? "23" : "18";
+	}
+
+	const num = parseInt(settings.videoQuality, 10);
+	return isNaN(num) ? "23" : num.toString();
+}
+
 /**
  * @param {File} file
  * @param {{ encoder: string; speed: string; videoQuality: string; audioQuality: string; audioFormat: string }} settings
  * @param {string} outputPath
  */
-function buildFFmpegArgs(file, settings, outputPath) {
+async function buildFFmpegArgs(file, settings, outputPath) {
 	const inputPath = file.path;
 	console.log("Output path: " + outputPath);
 
 	const args = ["-hide_banner", "-y", "-stats", "-i", inputPath];
-	const quality = parseInt(settings.videoQuality, 10).toString();
+
+	let useBitrate = false;
+	let videoBitrate = 0;
+
+	if (settings.videoQuality === "target-size") {
+		try {
+			const duration = await getVideoDuration(inputPath);
+			if (duration > 0) {
+				const targetSizeMB = parseFloat(settings.targetSize);
+				if (!isNaN(targetSizeMB) && targetSizeMB > 0) {
+					const targetSizeBytes = targetSizeMB * 1024 * 1024;
+					const targetBitrateBits = (targetSizeBytes * 8) / duration;
+
+					// Reserve 128k for audio
+					const audioBitrate = 128000;
+					videoBitrate = targetBitrateBits - audioBitrate;
+
+					// Set a minimum threshold for video bitrate
+					if (videoBitrate < 100000) {
+						videoBitrate = Math.max(50000, targetBitrateBits * 0.8);
+					}
+					useBitrate = true;
+				}
+			}
+		} catch (error) {
+			console.error(
+				"Failed to estimate duration for bitrate calculation, falling back to CRF 23",
+				error,
+			);
+		}
+	}
+
+	if (settings.videoQuality === "target-percent") {
+		try {
+			const duration = await getVideoDuration(inputPath);
+			if (duration > 0) {
+				const targetPercent = parseFloat(settings.targetPercent);
+				if (
+					!isNaN(targetPercent) &&
+					targetPercent > 0 &&
+					targetPercent <= 100
+				) {
+					// Calculate target bytes based on the input File size property
+					const targetSizeBytes = file.size * (targetPercent / 100);
+					const targetBitrateBits = (targetSizeBytes * 8) / duration;
+
+					// Reserve 128k for audio
+					const audioBitrate = 128000;
+					videoBitrate = targetBitrateBits - audioBitrate;
+
+					// Set a minimum threshold for video bitrate
+					if (videoBitrate < 100000) {
+						videoBitrate = Math.max(50000, targetBitrateBits * 0.8);
+					}
+					useBitrate = true;
+				}
+			}
+		} catch (error) {
+			console.error(
+				"Failed to estimate duration for percentage calculation, falling back to CRF 23",
+				error,
+			);
+		}
+	}
+
+	const quality = getCRFValue(settings);
 
 	switch (settings.encoder) {
 		case "copy":
@@ -347,9 +443,12 @@ function buildFFmpegArgs(file, settings, outputPath) {
 				settings.speed,
 				"-vf",
 				"format=yuv420p",
-				"-crf",
-				quality,
 			);
+			if (useBitrate) {
+				args.push("-b:v", Math.round(videoBitrate).toString());
+			} else {
+				args.push("-crf", quality);
+			}
 			break;
 		case "x265":
 			args.push(
@@ -359,9 +458,12 @@ function buildFFmpegArgs(file, settings, outputPath) {
 				"format=yuv420p",
 				"-preset",
 				settings.speed,
-				"-crf",
-				quality,
 			);
+			if (useBitrate) {
+				args.push("-b:v", Math.round(videoBitrate).toString());
+			} else {
+				args.push("-crf", quality);
+			}
 			break;
 		case "qsv":
 			args.push(
@@ -371,9 +473,27 @@ function buildFFmpegArgs(file, settings, outputPath) {
 				"format=yuv420p",
 				"-preset",
 				settings.speed,
-				"-global_quality",
-				quality,
 			);
+			if (useBitrate) {
+				args.push("-b:v", Math.round(videoBitrate).toString());
+			} else {
+				args.push("-global_quality", quality);
+			}
+			break;
+		case "hevc_qsv":
+			args.push(
+				"-c:v",
+				"hevc_qsv",
+				"-vf",
+				"format=yuv420p",
+				"-preset",
+				settings.speed,
+			);
+			if (useBitrate) {
+				args.push("-b:v", Math.round(videoBitrate).toString());
+			} else {
+				args.push("-global_quality", quality);
+			}
 			break;
 		case "vaapi":
 			args.push(
@@ -383,9 +503,12 @@ function buildFFmpegArgs(file, settings, outputPath) {
 				"format=nv12,hwupload",
 				"-c:v",
 				"h264_vaapi",
-				"-qp",
-				quality,
 			);
+			if (useBitrate) {
+				args.push("-b:v", Math.round(videoBitrate).toString());
+			} else {
+				args.push("-qp", quality);
+			}
 			break;
 		case "hevc_vaapi":
 			args.push(
@@ -395,9 +518,12 @@ function buildFFmpegArgs(file, settings, outputPath) {
 				"format=nv12,hwupload",
 				"-c:v",
 				"hevc_vaapi",
-				"-qp",
-				quality,
 			);
+			if (useBitrate) {
+				args.push("-b:v", Math.round(videoBitrate).toString());
+			} else {
+				args.push("-qp", quality);
+			}
 			break;
 		case "nvenc":
 			args.push(
@@ -407,11 +533,27 @@ function buildFFmpegArgs(file, settings, outputPath) {
 				"format=yuv420p",
 				"-preset",
 				getNvencPreset(settings.speed),
-				"-rc",
-				"vbr",
-				"-cq",
-				quality,
 			);
+			if (useBitrate) {
+				args.push("-b:v", Math.round(videoBitrate).toString());
+			} else {
+				args.push("-rc", "vbr", "-cq", quality);
+			}
+			break;
+		case "hevc_nvenc":
+			args.push(
+				"-c:v",
+				"hevc_nvenc",
+				"-vf",
+				"format=yuv420p",
+				"-preset",
+				getNvencPreset(settings.speed),
+			);
+			if (useBitrate) {
+				args.push("-b:v", Math.round(videoBitrate).toString());
+			} else {
+				args.push("-rc", "vbr", "-cq", quality);
+			}
 			break;
 		case "hevc_amf": {
 			const speedToQuality = {slow: "quality", fast: "speed"};
@@ -424,13 +566,17 @@ function buildFFmpegArgs(file, settings, outputPath) {
 				"format=yuv420p",
 				"-quality",
 				amf_hevc_quality,
-				"-rc",
-				"cqp",
-				"-qp_i",
-				quality,
-				"-qp_p",
-				quality,
 			);
+			if (useBitrate) {
+				args.push(
+					"-rc",
+					"cbr",
+					"-b:v",
+					Math.round(videoBitrate).toString(),
+				);
+			} else {
+				args.push("-rc", "cqp", "-qp_i", quality, "-qp_p", quality);
+			}
 			break;
 		}
 		case "amf": {
@@ -443,30 +589,56 @@ function buildFFmpegArgs(file, settings, outputPath) {
 				"format=yuv420p",
 				"-quality",
 				amf_quality,
-				"-rc",
-				"cqp",
-				"-qp_i",
-				quality,
-				"-qp_p",
-				quality,
-				"-qp_b",
-				quality,
 			);
+			if (useBitrate) {
+				args.push(
+					"-rc",
+					"cbr",
+					"-b:v",
+					Math.round(videoBitrate).toString(),
+				);
+			} else {
+				args.push(
+					"-rc",
+					"cqp",
+					"-qp_i",
+					quality,
+					"-qp_p",
+					quality,
+					"-qp_b",
+					quality,
+				);
+			}
 			break;
 		}
 		case "videotoolbox":
-			args.push(
-				"-c:v",
-				"h264_videotoolbox",
-				"-vf",
-				"format=yuv420p",
-				"-q:v",
-				quality,
-			);
+			args.push("-c:v", "h264_videotoolbox", "-vf", "format=yuv420p");
+			if (useBitrate) {
+				args.push("-b:v", Math.round(videoBitrate).toString());
+			} else {
+				args.push("-q:v", quality);
+			}
+			break;
+		case "hevc_videotoolbox":
+			args.push("-c:v", "hevc_videotoolbox", "-vf", "format=yuv420p");
+			if (useBitrate) {
+				args.push("-b:v", Math.round(videoBitrate).toString());
+			} else {
+				args.push("-q:v", quality);
+			}
 			break;
 	}
 
-	args.push("-c:a", settings.audioFormat, outputPath);
+	const audioFormat =
+		useBitrate && settings.audioFormat === "copy"
+			? "aac"
+			: settings.audioFormat;
+
+	args.push("-c:a", settings.audioFormat);
+	if (audioFormat !== "copy") {
+		args.push("-b:a", "128k");
+	}
+	args.push(outputPath);
 	return args;
 }
 
@@ -482,6 +654,10 @@ function getEncoderSettings() {
 		extension: dom.fileExtension.value,
 		outputPath: dom.customFolderPath.textContent,
 		outputSuffix: dom.outputSuffix.value,
+		targetSize: dom.targetSizeInput ? dom.targetSizeInput.value : "25",
+		targetPercent: dom.targetPercentInput
+			? dom.targetPercentInput.value
+			: "50",
 	};
 }
 
@@ -529,6 +705,7 @@ function createProgressItem(filename, status, data, itemId) {
         <div id="${itemId}_prog" class="itemProgress">${data}</div>
     `;
 	dom.compressionStatus.append(newStatus);
+	dom.compressionStatus.scrollIntoView({behavior: "smooth", block: "end"});
 }
 
 /**
@@ -627,3 +804,133 @@ Object.entries(menuRoutes).forEach(([domKey, route]) => {
 		ipcRenderer.send(route.channel, __dirname + route.page);
 	});
 });
+
+// Target Size / CRF Mode helper functions
+function getFfprobePath() {
+	const ffmpegPath = getFfmpegPath();
+	if (!ffmpegPath) return "";
+	const dir = path.dirname(ffmpegPath);
+	const ext = os.platform() === "win32" ? ".exe" : "";
+	return path.join(dir, "ffprobe" + ext);
+}
+
+function getVideoDuration(filePath) {
+	const ffprobe = getFfprobePath();
+	return new Promise((resolve, reject) => {
+		const child = spawn(ffprobe, [
+			"-v",
+			"error",
+			"-show_entries",
+			"format=duration",
+			"-of",
+			"default=noprint_wrappers=1:nokey=1",
+			filePath,
+		]);
+		let output = "";
+		const timeout = setTimeout(() => {
+			child.kill();
+			reject(new Error("ffprobe timeout"));
+		}, 10000);
+		child.stdout.on("data", (data) => {
+			output += data.toString();
+		});
+		child.on("close", (code) => {
+			clearTimeout(timeout);
+			if (code === 0) {
+				const duration = parseFloat(output.trim());
+				if (!isNaN(duration)) {
+					resolve(duration);
+				} else {
+					reject(new Error("Invalid duration format"));
+				}
+			} else {
+				reject(new Error(`ffprobe exited with code ${code}`));
+			}
+		});
+		child.on("error", (err) => {
+			clearTimeout(timeout);
+			reject(err);
+		});
+	});
+}
+
+function updateCRFDisplay(crf) {
+	const valElem = getId("crf-val");
+	if (valElem) valElem.textContent = crf;
+
+	let descKey = "qualityBalancedDesc";
+	if (crf <= 20) {
+		descKey = "qualityHighDesc";
+	} else if (crf <= 25) {
+		descKey = "qualityBalancedDesc";
+	} else if (crf <= 28) {
+		descKey = "qualitySmallFileDesc";
+	} else {
+		descKey = "qualityCustomDesc";
+	}
+
+	const descElem = getId("crf-desc");
+	if (descElem) {
+		descElem.textContent = window.i18n ? window.i18n.__(descKey) : descKey;
+	}
+}
+
+// Listeners for Video Quality Presets & Accordion
+document.querySelectorAll(".preset-btn").forEach((btn) => {
+	btn.addEventListener("click", () => {
+		document
+			.querySelectorAll(".preset-btn")
+			.forEach((b) => b.classList.remove("active"));
+		btn.classList.add("active");
+
+		const quality = btn.getAttribute("data-quality");
+
+		if (quality === "custom") {
+			dom.customQualityContainer.style.display = "block";
+			dom.targetSizeContainer.style.display = "none";
+			dom.targetPercentContainer.style.display = "none";
+			const sliderVal = parseInt(dom.qualitySlider.value, 10);
+			const crf = 69 - sliderVal;
+			dom.videoQuality.value = crf.toString();
+			updateCRFDisplay(crf);
+		} else if (quality === "target-size") {
+			dom.customQualityContainer.style.display = "none";
+			dom.targetSizeContainer.style.display = "block";
+			dom.targetPercentContainer.style.display = "none";
+			dom.videoQuality.value = "target-size";
+		} else if (quality === "target-percent") {
+			dom.customQualityContainer.style.display = "none";
+			dom.targetSizeContainer.style.display = "none";
+			dom.targetPercentContainer.style.display = "block";
+			dom.videoQuality.value = "target-percent";
+		} else {
+			dom.customQualityContainer.style.display = "none";
+			dom.targetSizeContainer.style.display = "none";
+			dom.targetPercentContainer.style.display = "none";
+			dom.videoQuality.value = quality;
+		}
+	});
+});
+
+if (dom.qualitySlider) {
+	dom.qualitySlider.addEventListener("input", (e) => {
+		const val = parseInt(e.target.value, 10);
+		const crf = 69 - val;
+		dom.videoQuality.value = crf.toString();
+		updateCRFDisplay(crf);
+	});
+}
+
+if (dom.advancedToggleBtn) {
+	dom.advancedToggleBtn.addEventListener("click", () => {
+		const isCollapsed =
+			dom.advancedSettingsCollapse.classList.contains("collapsed");
+		if (isCollapsed) {
+			dom.advancedSettingsCollapse.classList.remove("collapsed");
+			dom.advancedToggleBtn.classList.add("expanded");
+		} else {
+			dom.advancedSettingsCollapse.classList.add("collapsed");
+			dom.advancedToggleBtn.classList.remove("expanded");
+		}
+	});
+}

--- a/translations/en.json
+++ b/translations/en.json
@@ -168,6 +168,22 @@
 	"learnMore": "Learn more",
 	"updateError": "An error occurred during the update process",
 	"unableToAccessDir": "The program cannot access that folder",
-	"downloadingUpdate": "Downloading update"
-
+	"downloadingUpdate": "Downloading update",
+	"qualitySmallFile": "Small File",
+	"qualitySmallFileDesc": "Decent quality, smaller size",
+	"qualityBalanced": "Balanced",
+	"qualityBalancedDesc": "Recommended",
+	"qualityHigh": "High Quality",
+	"qualityHighDesc": "Excellent detail, larger size",
+	"qualityCustom": "Custom",
+	"qualityCustomDesc": "Choose exact CRF",
+	"qualityTargetSize": "Target Size",
+	"qualityTargetSizeDesc": "Specify target MB",
+	"targetSizeMB": "Target Size (MB)",
+	"worst": "Worst",
+	"best": "Best",
+	"advancedSettings": "Advanced Settings",
+	"qualityTargetPercent": "Target %",
+	"qualityTargetPercentDesc": "Set target % of size",
+	"targetPercentLabel": "Target Percentage (%)"
 }


### PR DESCRIPTION
## Summary

Redesign the Video Compressor page to be much simpler and more intuitive for users, while preserving all technical power in a collapsible Advanced Settings panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Updated the video quality UI to include always-visible preset buttons (Small, Balanced, High) and mode switchers (Custom, Target Size, Target Percent)
  * Added Custom quality slider controls for CRF-based tuning
  * Introduced Target Size and Target Percent compression modes with corresponding inputs
  * Expanded advanced settings to focus on format/encoder/audio-related options
* **Bug Fixes**
  * Improved compression progress tracking by scrolling the status area into view smoothly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->