### PR TITLE
Disable node integration and use preload script

### DIFF
--- a/html/about.html
+++ b/html/about.html
@@ -8,6 +8,7 @@
     <title data-translate="about">About</title>
     <link rel="stylesheet" href="../assets/css/extra.css">
 
+    <script src="../translations/i18n.js" defer></script>
     <script src="../translations/i18n-init.js" defer></script>
 </head>
 
@@ -29,7 +30,7 @@
         data-translate="here">here</a>
 
     <script>
-        const { ipcRenderer, shell } = require("electron");
+        const { ipcRenderer, shell } = window.electronAPI;
 
 
         document.addEventListener('translations-loaded', () => {

--- a/html/compressor.html
+++ b/html/compressor.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-translate="compressor">Video Compressor</title>
     <link rel="stylesheet" href="../assets/css/index.css">
+    <script src="../translations/i18n.js" defer></script>
     <script src="../translations/i18n-init.js" defer></script>
     <script src="../src/compressor.js" defer></script>
 </head>

--- a/html/history.html
+++ b/html/history.html
@@ -447,10 +447,11 @@
 
     <div id="popupContainer" class="popup-container"></div>
 
+    <script src="../translations/i18n.js"></script>
     <script src="../translations/i18n-init.js"></script>
 
     <script>
-        const { ipcRenderer } = require("electron");
+        const { ipcRenderer, clipboard } = window.electronAPI;
 
         document.addEventListener('translations-loaded', () => {
             window.i18n.translatePage();
@@ -714,7 +715,6 @@
         }
 
         function copyToClipboard(text) {
-            const { clipboard } = require("electron");
             clipboard.writeText(text);
             showPopup(i18n.__("urlCopiedToClipboard"));
         }

--- a/html/index.html
+++ b/html/index.html
@@ -13,6 +13,7 @@
 
     <link rel="stylesheet" href="../assets/css/index.css">
 
+    <script src="../translations/i18n.js" defer></script>
     <script src="../translations/i18n-init.js" defer></script>
     <script src="../src/renderer.js" defer></script>
     <script src="../src/index.js" defer></script>
@@ -320,7 +321,7 @@
     <div id="goToTop"></div>
 
     <script>
-        const os = require("os")
+        const os = window.electronAPI.os;
 
         if (os.platform() === "darwin") {
             document.getElementById("pasteCtrlKey").textContent = "⌘";

--- a/html/playlist.html
+++ b/html/playlist.html
@@ -133,7 +133,7 @@
             <div id="typeSelectBox">
                 <label id="videoQualityTxt" data-translate="selectVideoFormat">Select video quality</label>
                 <select id="videoTypeSelect" class="select">
-                    <option value="auto" id="autoTxt" data-translate="auto">Auto</option>
+                    <option value="auto" id="autoTxt" data-translate="auto" selected>Auto</option>
                     <option value="mp4">Mp4</option>
                     <option value="webm">WebM</option>
                 </select>
@@ -147,7 +147,7 @@
 
             <label id="audioFormat" data-translate="selectAudioFormat">Select Audio format </label>
             <select id="audioSelect" class="select">
-                <option value="mp3">Mp3</option>
+                <option value="mp3" selected>Mp3</option>
                 <option value="m4a">M4a</option>
                 <option value="opus">Opus</option>
                 <option value="wav">Wav</option>
@@ -159,7 +159,7 @@
             <label class="audioQualitySelect" id="audioQualitySelectTxt" data-translate="selectQuality">Select
                 Quality</label>
             <select id="audioQualitySelect" class="select">
-                <option id="audioQualityAuto" value="auto" data-translate="auto">Auto</option>
+                <option id="audioQualityAuto" value="auto" data-translate="auto" selected>Auto</option>
                 <option id="audioQualityNormal" value="5" data-translate="qualityNormal">Normal</option>
                 <option id="audioQualityBest" value="0" data-translate="best">Best</option>
                 <option id="audioQualityGood" value="2" data-translate="qualityGood">Good</option>

--- a/html/playlist.html
+++ b/html/playlist.html
@@ -8,6 +8,7 @@
     <title data-translate="downloadPlaylistButton">Playlist download</title>
     <link rel="stylesheet" href="../assets/css/index.css">
 
+    <script src="../translations/i18n.js" defer></script>
     <script src="../translations/i18n-init.js" defer></script>
     <script src="../src/playlist.js" defer></script>
     <script src="../src/common.js" defer></script>

--- a/html/playlist_new.html
+++ b/html/playlist_new.html
@@ -7,10 +7,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Playlist download</title>
     <link rel="stylesheet" href="../assets/css/index.css">
+    <script src="../translations/i18n.js" defer></script>
+    <script src="../translations/i18n-init.js" defer></script>
     <script src="../src/playlist_new.js" defer></script>
     <script src="../src/common.js" defer></script>
-    <!-- Translating -->
-    <script>window.i18n = new (require('../translations/i18n'));</script>
     <style>
         .playlistCheck {
             position: absolute;

--- a/html/preferences.html
+++ b/html/preferences.html
@@ -8,6 +8,7 @@
     <title id="title" data-translate="preferences">Preferences</title>
     <link rel="stylesheet" href="../assets/css/extra.css">
 
+    <script src="../translations/i18n.js" defer></script>
     <script src="../translations/i18n-init.js" defer></script>
     <script src="../src/preferences.js" defer></script>
 </head>

--- a/html/search.html
+++ b/html/search.html
@@ -13,6 +13,7 @@
 
     <link rel="stylesheet" href="../assets/css/index.css">
 
+    <script src="../translations/i18n.js" defer></script>
     <script src="../translations/i18n-init.js" defer></script>
     <script src="../src/renderer.js" defer></script>
     <script src="../src/index.js" defer></script>

--- a/main.js
+++ b/main.js
@@ -108,8 +108,10 @@ function createWindow() {
 		show: false,
 		icon: path.join(__dirname, "/assets/images/icon.png"),
 		webPreferences: {
-			nodeIntegration: true,
-			contextIsolation: false,
+			nodeIntegration: false,
+			contextIsolation: true,
+			sandbox: false,
+			preload: path.join(__dirname, "preload.js"),
 			spellcheck: false,
 		},
 	});
@@ -163,8 +165,10 @@ function createSecondaryWindow(file) {
 		modal: true,
 		show: false,
 		webPreferences: {
-			nodeIntegration: true,
-			contextIsolation: false,
+			nodeIntegration: false,
+			contextIsolation: true,
+			sandbox: false,
+			preload: path.join(__dirname, "preload.js"),
 		},
 		width: 1000,
 		height: 800,
@@ -305,13 +309,31 @@ function registerIpcHandlers() {
 		}
 	});
 
+	function resolveHtmlPath(file) {
+		if (existsSync(file)) {
+			return file;
+		}
+		const basename = path.basename(file);
+		const htmlPath = path.join(__dirname, "html", basename);
+		if (existsSync(htmlPath)) {
+			return htmlPath;
+		}
+		const rootPath = path.join(__dirname, file);
+		if (existsSync(rootPath)) {
+			return rootPath;
+		}
+		return file;
+	}
+
 	ipcMain.on("load-win", (_event, file) => {
 		appState.indexPageIsOpen = file.includes("index.html");
-		appState.mainWindow?.loadFile(file);
+		const targetPath = resolveHtmlPath(file);
+		appState.mainWindow?.loadFile(targetPath);
 	});
 
 	ipcMain.on("load-page", (_event, file) => {
-		createSecondaryWindow(file);
+		const targetPath = resolveHtmlPath(file);
+		createSecondaryWindow(targetPath);
 	});
 
 	ipcMain.on("close-secondary", () => {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"files": [
 			"./resources/**/*",
 			"main.js",
+			"preload.js",
 			"./html/**/*",
 			"./resources/**/*",
 			"./public/**/*",

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,362 @@
+const { contextBridge, ipcRenderer, shell, clipboard } = require("electron");
+const path = require("path");
+const os = require("os");
+const fs = require("fs");
+const originalFs = require("original-fs");
+const { exec, execSync, spawn, spawnSync } = require("child_process");
+const crypto = require("crypto");
+const si = require("systeminformation");
+const { default: YTDlpWrap } = require("yt-dlp-wrap-plus");
+
+function normalizeSignal(options, cancellationSignal) {
+	let signalToUse = null;
+	const localOpts = options ? { ...options } : {};
+	const incomingSignal = localOpts.signal || cancellationSignal;
+
+	if (incomingSignal) {
+		if (incomingSignal instanceof AbortSignal) {
+			signalToUse = incomingSignal;
+		} else {
+			const ac = new AbortController();
+			signalToUse = ac.signal;
+			if (incomingSignal.aborted) {
+				ac.abort();
+			} else if (typeof incomingSignal.addEventListener === "function") {
+				incomingSignal.addEventListener("abort", () => ac.abort());
+			}
+		}
+	}
+
+	delete localOpts.signal;
+	return { options: localOpts, signal: signalToUse };
+}
+
+function killProcessSafely(proc, signal) {
+	if (!proc) return;
+	try {
+		if (process.platform === "win32" && proc.pid) {
+			execSync(`taskkill /pid ${proc.pid} /T /F`);
+		} else {
+			proc.kill(signal || "SIGKILL");
+		}
+	} catch (e) {
+		try {
+			proc.kill(signal || "SIGKILL");
+		} catch (_) { }
+	}
+}
+
+function createYTDlpWrapInstance(binaryPath) {
+	const instance = new YTDlpWrap(binaryPath);
+	return {
+		exec: (args = [], options = {}, cancellationSignal) => {
+			const { options: localOpts, signal: realSignal } = normalizeSignal(options, cancellationSignal);
+			const proc = instance.exec(args, localOpts, realSignal);
+			const spawnargs =
+				proc.ytDlpProcess && proc.ytDlpProcess.spawnargs
+					? [...proc.ytDlpProcess.spawnargs]
+					: Array.isArray(args)
+						? args
+						: [];
+
+			const procWrapper = {
+				on: (event, cb) => {
+					proc.on(event, (...eventArgs) => cb(...eventArgs));
+					return procWrapper;
+				},
+				once: (event, cb) => {
+					proc.once(event, (...eventArgs) => cb(...eventArgs));
+					return procWrapper;
+				},
+				off: (event, cb) => {
+					proc.off(event, (...eventArgs) => cb(...eventArgs));
+					return procWrapper;
+				},
+				removeListener: (event, cb) => {
+					proc.removeListener(event, (...eventArgs) => cb(...eventArgs));
+					return procWrapper;
+				},
+				removeAllListeners: (event) => {
+					proc.removeAllListeners(event);
+					return procWrapper;
+				},
+				ytDlpProcess: {
+					spawnargs: spawnargs,
+					kill: (signal) => killProcessSafely(proc.ytDlpProcess, signal),
+					get killed() {
+						return proc.ytDlpProcess ? proc.ytDlpProcess.killed : false;
+					},
+					get pid() {
+						return proc.ytDlpProcess ? proc.ytDlpProcess.pid : undefined;
+					},
+					stdout: {
+						on: (event, cb) => {
+							if (proc.ytDlpProcess && proc.ytDlpProcess.stdout) {
+								proc.ytDlpProcess.stdout.on(event, (data) =>
+									cb(typeof data === "string" ? data : data.toString()),
+								);
+							}
+						},
+					},
+					stderr: {
+						on: (event, cb) => {
+							if (proc.ytDlpProcess && proc.ytDlpProcess.stderr) {
+								proc.ytDlpProcess.stderr.on(event, (data) =>
+									cb(typeof data === "string" ? data : data.toString()),
+								);
+							}
+						},
+					},
+				},
+				kill: (signal) => killProcessSafely(proc.ytDlpProcess || proc, signal),
+				get killed() {
+					return proc.ytDlpProcess ? proc.ytDlpProcess.killed : false;
+				},
+			};
+			return procWrapper;
+		},
+		execPromise: (args = [], options = {}, cancellationSignal) => {
+			const { options: localOpts, signal: realSignal } = normalizeSignal(options, cancellationSignal);
+			return instance.execPromise(args, localOpts, realSignal);
+		},
+		getExtractorTitles: () => {
+			return instance.getExtractorTitles();
+		},
+		version: () => {
+			return instance.version();
+		},
+	};
+}
+
+function YTDlpWrapConstructor(binaryPath) {
+	return createYTDlpWrapInstance(binaryPath);
+}
+
+YTDlpWrapConstructor.downloadFromGithub = (filePath, version, platform, callback) => {
+	return YTDlpWrap.downloadFromGithub(
+		filePath,
+		version,
+		platform,
+		(progress, downloaded, total) => {
+			if (callback) callback(progress, downloaded, total);
+		},
+	);
+};
+
+const spawnWrapper = (command, args = [], options = {}) => {
+	const child = spawn(command, args, options);
+	const childWrapper = {
+		stdout: {
+			on: (event, cb) => {
+				child.stdout?.on(event, (data) =>
+					cb(typeof data === "string" ? data : data.toString()),
+				);
+			},
+		},
+		stderr: {
+			on: (event, cb) => {
+				child.stderr?.on(event, (data) =>
+					cb(typeof data === "string" ? data : data.toString()),
+				);
+			},
+		},
+		on: (event, cb) => {
+			child.on(event, (...eventArgs) => cb(...eventArgs));
+			return childWrapper;
+		},
+		once: (event, cb) => {
+			child.once(event, (...eventArgs) => cb(...eventArgs));
+			return childWrapper;
+		},
+		off: (event, cb) => {
+			child.off(event, (...eventArgs) => cb(...eventArgs));
+			return childWrapper;
+		},
+		removeListener: (event, cb) => {
+			child.removeListener(event, (...eventArgs) => cb(...eventArgs));
+			return childWrapper;
+		},
+		removeAllListeners: (event) => {
+			child.removeAllListeners(event);
+			return childWrapper;
+		},
+		kill: (signal) => killProcessSafely(child, signal),
+		get killed() {
+			return child.killed;
+		},
+		get pid() {
+			return child.pid;
+		},
+	};
+	return childWrapper;
+};
+
+const envObj = {
+	FLATPAK_ID: process.env.FLATPAK_ID,
+	LD_LIBRARY_PATH: process.env.LD_LIBRARY_PATH,
+	YTDOWNLOADER_NODE_PATH: process.env.YTDOWNLOADER_NODE_PATH,
+	YTDOWNLOADER_DENO_PATH: process.env.YTDOWNLOADER_DENO_PATH,
+	YTDOWNLOADER_FFMPEG_PATH: process.env.YTDOWNLOADER_FFMPEG_PATH,
+	YTDOWNLOADER_YTDLP_PATH: process.env.YTDOWNLOADER_YTDLP_PATH,
+	YTDOWNLOADER_AUTO_UPDATES: process.env.YTDOWNLOADER_AUTO_UPDATES,
+};
+
+contextBridge.exposeInMainWorld("electronAPI", {
+	ipcRenderer: {
+		send: (channel, ...args) => ipcRenderer.send(channel, ...args),
+		on: (channel, listener) => {
+			const sub = (event, ...args) => listener(event, ...args);
+			ipcRenderer.on(channel, sub);
+			return sub;
+		},
+		once: (channel, listener) => {
+			ipcRenderer.once(channel, (event, ...args) => listener(event, ...args));
+		},
+		removeListener: (channel, listener) => {
+			ipcRenderer.removeListener(channel, listener);
+		},
+		removeAllListeners: (channel) => {
+			ipcRenderer.removeAllListeners(channel);
+		},
+		invoke: (channel, ...args) => ipcRenderer.invoke(channel, ...args),
+	},
+	shell: {
+		openExternal: (url) => shell.openExternal(url),
+		showItemInFolder: (p) => shell.showItemInFolder(p),
+		openPath: (p) => shell.openPath(p),
+	},
+	clipboard: {
+		readText: () => clipboard.readText(),
+		writeText: (text) => clipboard.writeText(text),
+	},
+	path: {
+		join: (...args) => path.join(...args),
+		extname: (p) => path.extname(p),
+		basename: (p, ext) => path.basename(p, ext),
+		dirname: (p) => path.dirname(p),
+		resolve: (...args) => path.resolve(...args),
+		parse: (p) => path.parse(p),
+		format: (obj) => path.format(obj),
+		isAbsolute: (p) => path.isAbsolute(p),
+		normalize: (p) => path.normalize(p),
+		relative: (from, to) => path.relative(from, to),
+		sep: path.sep,
+	},
+	join: (...args) => path.join(...args),
+	extname: (p) => path.extname(p),
+	basename: (p, ext) => path.basename(p, ext),
+	dirname: (p) => path.dirname(p),
+	resolve: (...args) => path.resolve(...args),
+	parse: (p) => path.parse(p),
+	format: (obj) => path.format(obj),
+	isAbsolute: (p) => path.isAbsolute(p),
+	normalize: (p) => path.normalize(p),
+	relative: (from, to) => path.relative(from, to),
+	sep: path.sep,
+
+	os: {
+		platform: () => os.platform(),
+		homedir: () => os.homedir(),
+		tmpdir: () => os.tmpdir(),
+		cpus: () => os.cpus(),
+	},
+	platform: () => os.platform(),
+	homedir: () => os.homedir(),
+	tmpdir: () => os.tmpdir(),
+	cpus: () => os.cpus(),
+
+	fs: {
+		existsSync: (p) => fs.existsSync(p),
+		readFileSync: (p, options) => fs.readFileSync(p, options),
+		writeFileSync: (p, data, options) => fs.writeFileSync(p, data, options),
+		mkdirSync: (p, options) => fs.mkdirSync(p, options),
+		unlinkSync: (p) => fs.unlinkSync(p),
+		copyFileSync: (src, dest, flags) => fs.copyFileSync(src, dest, flags),
+		cpSync: (src, dest, options) => fs.cpSync ? fs.cpSync(src, dest, options) : null,
+		accessSync: (p, mode) => fs.accessSync(p, mode),
+		rmSync: (p, options) => fs.rmSync(p, options),
+		readdirSync: (p, options) => fs.readdirSync(p, options),
+		statSync: (p) => fs.statSync(p),
+		lstatSync: (p) => fs.lstatSync(p),
+		promises: {
+			readFile: (p, options) => fs.promises.readFile(p, options),
+			writeFile: (p, data, options) => fs.promises.writeFile(p, data, options),
+			access: (p, mode) => fs.promises.access(p, mode),
+			unlink: (p) => fs.promises.unlink(p),
+			stat: (p) => fs.promises.stat(p),
+			lstat: (p) => fs.promises.lstat(p),
+			mkdir: (p, options) => fs.promises.mkdir(p, options),
+			readdir: (p, options) => fs.promises.readdir(p, options),
+		},
+		constants: {
+			W_OK: fs.constants.W_OK,
+			F_OK: fs.constants.F_OK,
+			R_OK: fs.constants.R_OK,
+			X_OK: fs.constants.X_OK,
+		},
+		originalFs: {
+			accessSync: (p, mode) => {
+				try {
+					return originalFs.accessSync(p, mode);
+				} catch (e) {
+					return fs.accessSync(p, mode);
+				}
+			},
+		},
+	},
+	existsSync: (p) => fs.existsSync(p),
+	readFileSync: (p, options) => fs.readFileSync(p, options),
+	writeFileSync: (p, data, options) => fs.writeFileSync(p, data, options),
+	mkdirSync: (p, options) => fs.mkdirSync(p, options),
+	unlinkSync: (p) => fs.unlinkSync(p),
+	copyFileSync: (src, dest, flags) => fs.copyFileSync(src, dest, flags),
+	cpSync: (src, dest, options) => fs.cpSync ? fs.cpSync(src, dest, options) : null,
+	accessSync: (p, mode) => {
+		try {
+			return originalFs.accessSync(p, mode);
+		} catch (e) {
+			return fs.accessSync(p, mode);
+		}
+	},
+	rmSync: (p, options) => fs.rmSync(p, options),
+	readdirSync: (p, options) => fs.readdirSync(p, options),
+	statSync: (p) => fs.statSync(p),
+	lstatSync: (p) => fs.lstatSync(p),
+	promises: {
+		readFile: (p, options) => fs.promises.readFile(p, options),
+		writeFile: (p, data, options) => fs.promises.writeFile(p, data, options),
+		access: (p, mode) => fs.promises.access(p, mode),
+		unlink: (p) => fs.promises.unlink(p),
+		stat: (p) => fs.promises.stat(p),
+		lstat: (p) => fs.promises.lstat(p),
+		mkdir: (p, options) => fs.promises.mkdir(p, options),
+		readdir: (p, options) => fs.promises.readdir(p, options),
+	},
+	constants: {
+		W_OK: fs.constants.W_OK,
+		F_OK: fs.constants.F_OK,
+		R_OK: fs.constants.R_OK,
+		X_OK: fs.constants.X_OK,
+	},
+
+	spawn: spawnWrapper,
+	spawnSync: (command, args, options) => spawnSync(command, args, options),
+	exec: (command, options, callback) => exec(command, options, callback),
+	execSync: (command, options) => execSync(command, options),
+	si: {
+		graphics: () => si.graphics(),
+	},
+	crypto: {
+		randomUUID: () => crypto.randomUUID(),
+		randomBytes: (size) => crypto.randomBytes(size),
+	},
+	YTDlpWrap: YTDlpWrapConstructor,
+	getEnv: (key) => process.env[key],
+	env: envObj,
+	setEnv: (key, value) => {
+		process.env[key] = value;
+		envObj[key] = value;
+	},
+	windowsStore: process.windowsStore,
+	__dirname: path.join(__dirname, "html"),
+});

--- a/src/common.js
+++ b/src/common.js
@@ -1,4 +1,3 @@
-const electron = require("electron");
 /**
  *
  * @param {string} id

--- a/src/compressor.js
+++ b/src/compressor.js
@@ -1,10 +1,15 @@
-const {spawn, execSync} = require("child_process");
-const path = require("path");
-const {ipcRenderer} = require("electron");
-const os = require("os");
-const si = require("systeminformation");
-const {existsSync} = require("fs");
-const crypto = require("crypto");
+const {
+	spawn,
+	execSync,
+	path,
+	ipcRenderer,
+	os,
+	si,
+	fs: {existsSync},
+	crypto,
+	env,
+	__dirname,
+} = window.electronAPI;
 
 document.addEventListener("translations-loaded", () => {
 	window.i18n.translatePage();
@@ -932,11 +937,12 @@ function timeToSeconds(timeStr) {
 
 function getFfmpegPath() {
 	if (
-		process.env.YTDOWNLOADER_FFMPEG_PATH &&
-		existsSync(process.env.YTDOWNLOADER_FFMPEG_PATH)
+		env &&
+		env.YTDOWNLOADER_FFMPEG_PATH &&
+		existsSync(env.YTDOWNLOADER_FFMPEG_PATH)
 	) {
 		console.log("Using FFMPEG from YTDOWNLOADER_FFMPEG_PATH");
-		return process.env.YTDOWNLOADER_FFMPEG_PATH;
+		return env.YTDOWNLOADER_FFMPEG_PATH;
 	}
 
 	switch (os.platform()) {

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -1,10 +1,15 @@
-const {clipboard, ipcRenderer} = require("electron");
-const {default: YTDlpWrap} = require("yt-dlp-wrap-plus");
-const path = require("path");
-const os = require("os");
-const fs = require("fs");
-const {execSync} = require("child_process");
-const {constants} = require("fs/promises");
+const {
+	clipboard,
+	ipcRenderer,
+	YTDlpWrap,
+	path,
+	os,
+	fs,
+	execSync,
+	constants,
+	env,
+	__dirname,
+} = window.electronAPI;
 
 const playlistDownloader = {
 	// State and config
@@ -511,6 +516,7 @@ const playlistDownloader = {
 
 				count++;
 				this.state.originalCount++;
+				this.state.currentLocalCount = count;
 				this.updatePlaylistUI(videoInfo, count, type);
 			}
 		});
@@ -545,15 +551,32 @@ const playlistDownloader = {
 				console.error("Failed to abort controller:", e);
 			}
 		}
-		if (
-			this.state.currentDownloadProcess &&
-			this.state.currentDownloadProcess.ytDlpProcess
-		) {
+		if (this.state.currentDownloadProcess) {
 			try {
-				this.state.currentDownloadProcess.ytDlpProcess.kill();
-			} catch (e) {
-				console.error("Failed to kill ytDlpProcess:", e);
+				if (typeof this.state.currentDownloadProcess.kill === "function") {
+					this.state.currentDownloadProcess.kill();
+				}
+			} catch (e) {}
+			if (
+				this.state.currentDownloadProcess.ytDlpProcess &&
+				typeof this.state.currentDownloadProcess.ytDlpProcess.kill === "function"
+			) {
+				try {
+					this.state.currentDownloadProcess.ytDlpProcess.kill();
+				} catch (e) {}
 			}
+		}
+		this.handleCancellation(this.state.currentLocalCount || 0);
+	},
+
+	handleCancellation(count) {
+		this.state.isDownloading = false;
+		this.ui.stopDownloadBtn.style.display = "none";
+		this.ui.pasteLinkBtn.style.display = "inline-block";
+		const targetCount = count !== undefined ? count : (this.state.currentLocalCount || 0);
+		const lastProgress = document.getElementById(`p${targetCount}`);
+		if (lastProgress) {
+			lastProgress.textContent = window.i18n ? window.i18n.__("cancel") : "Cancelled";
 		}
 	},
 
@@ -725,20 +748,13 @@ const playlistDownloader = {
 	},
 
 	finishDownload(count) {
+		if (this.state.isCancelled) {
+			this.handleCancellation(count);
+			return;
+		}
 		if (!this.state.isDownloading) return;
 		this.state.isDownloading = false;
 		this.ui.stopDownloadBtn.style.display = "none";
-
-		if (this.state.isCancelled) {
-			this.state.isCancelled = false;
-			const lastProgress = document.getElementById(`p${count}`);
-			if (lastProgress) {
-				lastProgress.textContent = window.i18n.__("cancel");
-			}
-			// this.ui.playlistNameDisplay.textContent = window.i18n.__("cancel");
-			this.ui.pasteLinkBtn.style.display = "inline-block";
-			return;
-		}
 
 		const lastProgress = document.getElementById(`p${count}`);
 		if (lastProgress)
@@ -755,15 +771,12 @@ const playlistDownloader = {
 	},
 
 	showError(error) {
-		const wasDownloading = this.state.isDownloading;
-		this.state.isDownloading = false;
-		this.ui.stopDownloadBtn.style.display = "none";
-
-		if (this.state.isCancelled && wasDownloading) {
-			this.state.isCancelled = false;
-			this.ui.pasteLinkBtn.style.display = "inline-block";
+		if (this.state.isCancelled) {
+			this.handleCancellation(this.state.currentLocalCount || 0);
 			return;
 		}
+		this.state.isDownloading = false;
+		this.ui.stopDownloadBtn.style.display = "none";
 
 		console.error("Download Error:", error.toString());
 		this.ui.pasteLinkBtn.style.display = "inline-block";
@@ -848,12 +861,13 @@ const playlistDownloader = {
 
 	getFfmpegPath() {
 		if (
-			process.env.YTDOWNLOADER_FFMPEG_PATH &&
-			fs.existsSync(process.env.YTDOWNLOADER_FFMPEG_PATH)
+			env &&
+			env.YTDOWNLOADER_FFMPEG_PATH &&
+			fs.existsSync(env.YTDOWNLOADER_FFMPEG_PATH)
 		) {
 			console.log("Using FFMPEG from YTDOWNLOADER_FFMPEG_PATH");
 
-			return process.env.YTDOWNLOADER_FFMPEG_PATH;
+			return env.YTDOWNLOADER_FFMPEG_PATH;
 		}
 
 		switch (os.platform()) {
@@ -885,17 +899,17 @@ const playlistDownloader = {
 		{
 			const exeName = "node";
 
-			if (process.env.YTDOWNLOADER_NODE_PATH) {
-				if (fs.existsSync(process.env.YTDOWNLOADER_NODE_PATH)) {
-					return `$node:${process.env.YTDOWNLOADER_NODE_PATH}`;
+			if (env && env.YTDOWNLOADER_NODE_PATH) {
+				if (fs.existsSync(env.YTDOWNLOADER_NODE_PATH)) {
+					return `$node:${env.YTDOWNLOADER_NODE_PATH}`;
 				}
 
 				return "";
 			}
 
-			if (process.env.YTDOWNLOADER_DENO_PATH) {
-				if (fs.existsSync(process.env.YTDOWNLOADER_DENO_PATH)) {
-					return `$deno:${process.env.YTDOWNLOADER_DENO_PATH}`;
+			if (env && env.YTDOWNLOADER_DENO_PATH) {
+				if (fs.existsSync(env.YTDOWNLOADER_DENO_PATH)) {
+					return `$deno:${env.YTDOWNLOADER_DENO_PATH}`;
 				}
 
 				return "";

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -137,15 +137,23 @@ const playlistDownloader = {
 		this.state.ffmpegPath = this.getFfmpegPath();
 		this.state.jsRuntimePath = this.getJsRuntimePath();
 
-		if (localStorage.getItem("preferredVideoQuality")) {
-			this.ui.videoQualitySelect.value = localStorage.getItem(
-				"preferredVideoQuality",
-			);
+		const preferredVideo = localStorage.getItem("preferredVideoQuality");
+		if (preferredVideo) {
+			this.ui.videoQualitySelect.value = preferredVideo;
 		}
-		if (localStorage.getItem("preferredAudioQuality")) {
-			this.ui.audioQualitySelect.value = localStorage.getItem(
-				"preferredAudioQuality",
-			);
+		if (!this.ui.videoQualitySelect.value) {
+			this.ui.videoQualitySelect.value = "best";
+		}
+
+		const preferredAudioFormat = localStorage.getItem("preferredAudioQuality");
+		if (preferredAudioFormat && this.ui.audioTypeSelect) {
+			this.ui.audioTypeSelect.value = preferredAudioFormat;
+		}
+		if (this.ui.audioTypeSelect && !this.ui.audioTypeSelect.value) {
+			this.ui.audioTypeSelect.value = "mp3";
+		}
+		if (this.ui.audioQualitySelect && !this.ui.audioQualitySelect.value) {
+			this.ui.audioQualitySelect.value = "auto";
 		}
 	},
 

--- a/src/playlist_new.js
+++ b/src/playlist_new.js
@@ -1,14 +1,21 @@
-const { clipboard, shell, ipcRenderer } = require("electron");
-const { default: YTDlpWrap } = require("yt-dlp-wrap-plus");
-const path = require("path");
-const os = require("os");
-const fs = require("fs");
-const { execSync, exec, spawnSync } = require("child_process");
+const {
+	clipboard,
+	shell,
+	ipcRenderer,
+	YTDlpWrap,
+	path,
+	os,
+	fs,
+	execSync,
+	exec,
+	spawnSync,
+	__dirname,
+} = window.electronAPI;
 let url;
 const ytDlp = localStorage.getItem("ytdlp");
 const ytdlp = new YTDlpWrap(ytDlp);
 const downloadDir = localStorage.getItem("downloadPath");
-const i18n = new (require("../translations/i18n"))();
+const i18n = window.i18n;
 let cookieArg = "";
 let browser = "";
 const formats = {

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -1,9 +1,15 @@
-const {ipcRenderer, shell} = require("electron");
-const {accessSync, constants} = require("original-fs");
-const fs = require("fs");
-const {join} = require("path");
-const {homedir, platform} = require("os");
-const {exec} = require("child_process");
+const {
+	ipcRenderer,
+	shell,
+	accessSync,
+	constants,
+	fs,
+	join,
+	homedir,
+	platform,
+	exec,
+	env,
+} = window.electronAPI;
 
 function getId(id) {
 	return document.getElementById(id);
@@ -184,7 +190,7 @@ document.addEventListener("translations-loaded", () => {
 	window.i18n.translatePage();
 	document.title = window.i18n.__("preferences");
 
-	if (process.env.FLATPAK_ID) {
+	if (env && env.FLATPAK_ID) {
 		const flatpakEl = getId("flatpakTxt");
 		flatpakEl.addEventListener("click", () => {
 			shell.openExternal(

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,9 +1,13 @@
-const {shell, ipcRenderer, clipboard} = require("electron");
-const {default: YTDlpWrap} = require("yt-dlp-wrap-plus");
-const {constants} = require("fs/promises");
-const {homedir, platform} = require("os");
-const {join} = require("path");
 const {
+	shell,
+	ipcRenderer,
+	clipboard,
+	YTDlpWrap,
+	constants,
+	homedir,
+	platform,
+	tmpdir,
+	join,
 	mkdirSync,
 	accessSync,
 	promises,
@@ -11,9 +15,17 @@ const {
 	cpSync,
 	copyFileSync,
 	writeFileSync,
+	unlinkSync,
+	readFileSync,
+	readdirSync,
 	statSync,
-} = require("fs");
-const {execSync, spawn} = require("child_process");
+	execSync,
+	spawn,
+	env,
+	setEnv,
+	windowsStore,
+	__dirname,
+} = window.electronAPI;
 
 const CONSTANTS = {
 	DOM_IDS: {
@@ -272,8 +284,8 @@ class YtDownloaderApp {
 			autoUpdate = false;
 		}
 		if (
-			process.windowsStore ||
-			process.env.YTDOWNLOADER_AUTO_UPDATES === "0"
+			windowsStore ||
+			(env && env.YTDOWNLOADER_AUTO_UPDATES === "0")
 		) {
 			autoUpdate = false;
 		}
@@ -310,9 +322,9 @@ class YtDownloaderApp {
 		let executablePath = null;
 
 		// PRIORITY 1: Environment Variable
-		if (process.env.YTDOWNLOADER_YTDLP_PATH) {
-			if (existsSync(process.env.YTDOWNLOADER_YTDLP_PATH)) {
-				executablePath = process.env.YTDOWNLOADER_YTDLP_PATH;
+		if (env && env.YTDOWNLOADER_YTDLP_PATH) {
+			if (existsSync(env.YTDOWNLOADER_YTDLP_PATH)) {
+				executablePath = env.YTDOWNLOADER_YTDLP_PATH;
 			} else {
 				throw new Error(
 					"YTDOWNLOADER_YTDLP_PATH is set, but no file exists there.",
@@ -552,9 +564,9 @@ class YtDownloaderApp {
 	 */
 	async _findFfmpeg() {
 		// Priority 1: Environment Variable
-		if (process.env.YTDOWNLOADER_FFMPEG_PATH) {
-			if (existsSync(process.env.YTDOWNLOADER_FFMPEG_PATH)) {
-				return process.env.YTDOWNLOADER_FFMPEG_PATH;
+		if (env && env.YTDOWNLOADER_FFMPEG_PATH) {
+			if (existsSync(env.YTDOWNLOADER_FFMPEG_PATH)) {
+				return env.YTDOWNLOADER_FFMPEG_PATH;
 			}
 			throw new Error(
 				"YTDOWNLOADER_FFMPEG_PATH is set, but no file exists there.",
@@ -616,13 +628,13 @@ class YtDownloaderApp {
 			return;
 		}
 
-		const current = process.env.LD_LIBRARY_PATH;
+		const current = env ? env.LD_LIBRARY_PATH : undefined;
 		if (current) {
 			if (!current.split(":").includes(libDir)) {
-				process.env.LD_LIBRARY_PATH = `${libDir}:${current}`;
+				setEnv("LD_LIBRARY_PATH", `${libDir}:${current}`);
 			}
 		} else {
-			process.env.LD_LIBRARY_PATH = libDir;
+			setEnv("LD_LIBRARY_PATH", libDir);
 		}
 	}
 
@@ -634,18 +646,18 @@ class YtDownloaderApp {
 		const exeName = "node";
 
 		// Priority 1: Environment Variable (Node)
-		if (process.env.YTDOWNLOADER_NODE_PATH) {
-			if (existsSync(process.env.YTDOWNLOADER_NODE_PATH)) {
-				return `$node:${process.env.YTDOWNLOADER_NODE_PATH}`;
+		if (env && env.YTDOWNLOADER_NODE_PATH) {
+			if (existsSync(env.YTDOWNLOADER_NODE_PATH)) {
+				return `$node:${env.YTDOWNLOADER_NODE_PATH}`;
 			}
 
 			return "";
 		}
 
 		// Priority 2: Environment Variable (Deno)
-		if (process.env.YTDOWNLOADER_DENO_PATH) {
-			if (existsSync(process.env.YTDOWNLOADER_DENO_PATH)) {
-				return `$deno:${process.env.YTDOWNLOADER_DENO_PATH}`;
+		if (env && env.YTDOWNLOADER_DENO_PATH) {
+			if (existsSync(env.YTDOWNLOADER_DENO_PATH)) {
+				return `$deno:${env.YTDOWNLOADER_DENO_PATH}`;
 			}
 
 			return "";
@@ -1388,13 +1400,12 @@ class YtDownloaderApp {
 			.once("close", (code) => {
 				if (existsSync(tempFilePath)) {
 					try {
-						const fileContent = require("fs")
-							.readFileSync(tempFilePath, "utf-8")
+						const fileContent = readFileSync(tempFilePath, "utf-8")
 							.trim();
 						if (fileContent) {
 							actualFilePath = fileContent;
 						}
-						require("fs").unlinkSync(tempFilePath);
+						unlinkSync(tempFilePath);
 					} catch (e) {
 						console.error("Error reading temp file:", e);
 					}
@@ -1410,7 +1421,7 @@ class YtDownloaderApp {
 			.once("error", (error) => {
 				if (existsSync(tempFilePath)) {
 					try {
-						require("fs").unlinkSync(tempFilePath);
+						unlinkSync(tempFilePath);
 					} catch (e) {}
 				}
 				this.state.downloadedItems.add(randomId);
@@ -1633,7 +1644,7 @@ class YtDownloaderApp {
 		);
 
 		// Create a unique temporary file path to capture the exact filename from yt-dlp
-		const tmpDir = require("os").tmpdir();
+		const tmpDir = tmpdir();
 		const tempFilePath = join(tmpDir, `ytdlp_path_${randomId}.txt`);
 
 		// Tell yt-dlp to output the absolute final file path directly to the temp file
@@ -2184,7 +2195,7 @@ class YtDownloaderApp {
 		) {
 			try {
 				const originalTitle = this.state.videoInfo.title;
-				const dirFiles = require("fs").readdirSync(
+				const dirFiles = readdirSync(
 					this.state.downloadDir,
 				);
 				const looseTitle = originalTitle

--- a/translations/i18n-init.js
+++ b/translations/i18n-init.js
@@ -1,9 +1,9 @@
-const I18n = require("../translations/i18n");
-const i18n = new I18n();
+const I18nClass = window.I18n;
+const i18nInstance = new I18nClass();
 
 (async () => {
-	await i18n.init();
+	await i18nInstance.init();
 	document.dispatchEvent(new Event("translations-loaded"));
 })();
 
-window.i18n = i18n;
+window.i18n = i18nInstance;

--- a/translations/i18n.js
+++ b/translations/i18n.js
@@ -1,4 +1,5 @@
-const {ipcRenderer} = require("electron");
+const getIpcRenderer = () =>
+	window.electronAPI ? window.electronAPI.ipcRenderer : null;
 
 function normalizeLocale(locale) {
 	if (!locale) return "en";
@@ -35,9 +36,10 @@ async function getLocale() {
 
 	let locale = null;
 	try {
-		locale = await ipcRenderer.invoke("get-system-locale");
+		const ipc = getIpcRenderer();
+		if (ipc) locale = await ipc.invoke("get-system-locale");
 	} catch (e) {
-		console.log(e)
+		console.log(e);
 	}
 
 	if (!locale && typeof navigator !== "undefined") {
@@ -62,10 +64,13 @@ function I18n() {
 	this.init = async () => {
 		try {
 			this.locale = await getLocale();
-			this.loadedLanguage = await ipcRenderer.invoke(
-				"get-translation",
-				this.locale
-			);
+			const ipc = getIpcRenderer();
+			if (ipc) {
+				this.loadedLanguage = await ipc.invoke(
+					"get-translation",
+					this.locale,
+				);
+			}
 		} catch (error) {
 			console.error("Error loading translations:", error);
 			this.loadedLanguage = {};
@@ -102,14 +107,20 @@ function I18n() {
 	this.setLocale = async function (newLocale) {
 		const normalized = normalizeLocale(newLocale);
 		localStorage.setItem("locale", normalized);
-		this.loadedLanguage = await ipcRenderer.invoke(
-			"get-translation",
-			normalized
-		);
+		const ipc = getIpcRenderer();
+		if (ipc) {
+			this.loadedLanguage = await ipc.invoke(
+				"get-translation",
+				normalized,
+			);
+		}
 		this.locale = normalized;
 
 		this.translatePage();
 	};
 }
 
-module.exports = I18n;
+window.I18n = I18n;
+if (typeof module !== "undefined") {
+	module.exports = I18n;
+}


### PR DESCRIPTION
----
## Summary by Gitar

- **Security Improvements:**
    - Disabled `nodeIntegration` and enabled `contextIsolation` with a secure `preload.js` script
- **Preload API & Module Exposure:**
    - Exposed `window.electronAPI` to securely bridge Electron modules and environment variables to the renderer
- **Renderer & HTML Refactoring:**
    - Updated renderer and source scripts to consume APIs from `window.electronAPI` instead of direct `require('electron')` or `process.env` calls

<sub>This will update automatically on new commits.</sub>