### PR TITLE
fix: sanitize shell/subprocess call in preferences.js

### DIFF
--- a/src/preferences.js
+++ b/src/preferences.js
@@ -3,7 +3,7 @@ const {accessSync, constants} = require("original-fs");
 const fs = require("fs");
 const {join} = require("path");
 const {homedir, platform} = require("os");
-const {exec} = require("child_process");
+const {exec, execFile} = require("child_process");
 
 function getId(id) {
 	return document.getElementById(id);
@@ -125,7 +125,7 @@ updateDirectionality();
 const ytdlpPath = localStorage.getItem("ytdlp");
 console.log("yt-dlp path:", ytdlpPath);
 if (ytdlpPath) {
-	exec(`"${ytdlpPath}" --version`, (error, stdout, _stderr) => {
+	execFile(ytdlpPath, ["--version"], (error, stdout, _stderr) => {
 		if (error) {
 			console.error("Error executing yt-dlp:", error);
 		} else {

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -146,7 +146,7 @@ if (ytdlpPath) {
 			systemPath = stdout.trim().split("\n")[0];
 			console.log("System yt-dlp path:", systemPath);
 
-			exec(`"${systemPath}" --version`, (error, stdout, _stderr) => {
+			execFile(systemPath, ["--version"], (error, stdout, _stderr) => {
 				if (error) {
 					console.error("Error executing yt-dlp:", error);
 				} else {
@@ -163,7 +163,7 @@ if (ytdlpPath) {
 				return;
 			}
 			systemPath = stdout.trim();
-			exec(`"${systemPath}" --version`, (error, stdout, _stderr) => {
+			execFile(systemPath, ["--version"], (error, stdout, _stderr) => {
 				if (error) {
 					console.error("Error executing yt-dlp:", error);
 				}


### PR DESCRIPTION
## Summary

Replace shell-interpolated `exec()` calls in `src/preferences.js` with `execFile()` for all code paths that execute a resolved yt-dlp binary path.

## Changes

- `src/preferences.js`: four `exec(\`"${path}" --version\`)` calls → `execFile(path, ["--version"], ...)`
  - User-configured path (line 128, original fix)
  - System-resolved path on Windows (line 149)
  - System-resolved path on Unix/macOS (line 166)

The `exec("where yt-dlp")` and `exec("which yt-dlp")` calls use hardcoded strings with no variable interpolation and are unchanged.

## Rationale

**Correctness fix (independent of any security concern):** `exec(\`"${path}" --version\`)` breaks for any path containing a literal `"` or other shell metacharacters (e.g. a path installed under a directory with unusual naming). `execFile(path, ["--version"])` passes the argument directly via `argv` — no shell involved, no quoting needed.

**Defense in depth:** The app currently runs with `nodeIntegration: true` / `contextIsolation: false`, so a renderer-side attacker already has full Node.js access and wouldn't need to go through this code path at all. However, if the app ever adopts `contextIsolation: true` with a narrow `contextBridge` (the standard Electron hardening direction), `execFile` here means one fewer escalation point. The change costs nothing now.

## Behavior Preservation

`execFile` with `["--version"]` is a drop-in replacement for `exec(\`"${path}" --version\`)` for all valid paths. Output and error handling are identical.