### PR TITLE
Fix for appimages: dereference library symlinks on copy and improve LD_LIBRARY_PATH resolution

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -596,7 +596,7 @@ class YtDownloaderApp {
 		if (!existsSync(targetFfmpegFile)) {
 			if (existsSync(bundledDir)) {
 				try {
-					cpSync(bundledDir, targetDir, {recursive: true});
+					cpSync(bundledDir, targetDir, {recursive: true, dereference: true});
 				} catch {
 					console.error("Failed to copy bundled ffmpeg.");
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Bug fix:**
    - Added `dereference: true` to `cpSync` when copying bundled ffmpeg directory to resolve symlinks properly in AppImages.

<sub>This will update automatically on new commits.</sub>