### PR TITLE
Add playwright tests

### DIFF
--- a/main.js
+++ b/main.js
@@ -38,13 +38,14 @@ const appState = {
 	autoUpdateEnabled: false,
 };
 
-const gotTheLock = app.requestSingleInstanceLock();
+const isTestEnv = process.env.NODE_ENV === "test" || process.argv.includes("--is-test") || process.env.YTDOWNLOADER_TEST === "true";
+const gotTheLock = isTestEnv ? true : app.requestSingleInstanceLock();
 
 if (!gotTheLock) {
 	app.quit();
 } else {
 	app.on("second-instance", () => {
-		if (appState.mainWindow) {
+		if (appState.mainWindow && !isTestEnv) {
 			if (appState.mainWindow.isMinimized())
 				appState.mainWindow.restore();
 			appState.mainWindow.show();
@@ -122,7 +123,9 @@ function createWindow() {
 		if (appState.config.isMaximized) {
 			appState.mainWindow.maximize();
 		}
-		appState.mainWindow.show();
+		if (!isTestEnv) {
+			appState.mainWindow.show();
+		}
 	});
 
 	const saveBounds = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"yt-dlp-wrap-plus": "^2.4.3"
 			},
 			"devDependencies": {
+				"@playwright/test": "^1.45.0",
 				"electron": "^30.5.1",
 				"electron-builder": "^26.0.12",
 				"typescript": "^5.3.3"
@@ -853,6 +854,22 @@
 			"optional": true,
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+			"integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.62.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/@sindresorhus/is": {
@@ -2881,6 +2898,21 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4191,6 +4223,38 @@
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/playwright": {
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+			"integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.62.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+			"integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
+			}
 		},
 		"node_modules/plist": {
 			"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	"main": "main.js",
 	"scripts": {
 		"start": "electron .",
+		"test": "playwright test",
 		"dist": "electron-builder",
 		"debug": "electron --inspect=5858 .",
 		"windows": "electron-builder -w",
@@ -31,6 +32,7 @@
 	"license": "GPL-3.0",
 	"description": "Download videos and audios from YouTube and many other sites",
 	"devDependencies": {
+		"@playwright/test": "^1.45.0",
 		"electron": "^30.5.1",
 		"electron-builder": "^26.0.12",
 		"typescript": "^5.3.3"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,15 @@
+const { defineConfig } = require("@playwright/test");
+
+module.exports = defineConfig({
+	testDir: "./tests",
+	timeout: 30000,
+	expect: {
+		timeout: 5000,
+	},
+	fullyParallel: false,
+	workers: process.env.CI ? 2 : 4,
+	reporter: [["list"]],
+	use: {
+		trace: "on-first-retry",
+	},
+});

--- a/preload.js
+++ b/preload.js
@@ -8,6 +8,8 @@ const crypto = require("crypto");
 const si = require("systeminformation");
 const { default: YTDlpWrap } = require("yt-dlp-wrap-plus");
 
+const isTest = process.env.NODE_ENV === "test" || process.env.YTDOWNLOADER_TEST === "true" || (process.argv && process.argv.includes("--is-test"));
+
 function normalizeSignal(options, cancellationSignal) {
 	let signalToUse = null;
 	const localOpts = options ? { ...options } : {};
@@ -226,8 +228,14 @@ contextBridge.exposeInMainWorld("electronAPI", {
 		openPath: (p) => shell.openPath(p),
 	},
 	clipboard: {
-		readText: () => clipboard.readText(),
-		writeText: (text) => clipboard.writeText(text),
+		readText: () => (isTest ? window.__testClipboardText || "" : clipboard.readText()),
+		writeText: (text) => {
+			if (isTest) {
+				window.__testClipboardText = text;
+			} else {
+				clipboard.writeText(text);
+			}
+		},
 	},
 	path: {
 		join: (...args) => path.join(...args),
@@ -357,6 +365,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 		process.env[key] = value;
 		envObj[key] = value;
 	},
+	isTest: process.env.NODE_ENV === "test" || process.argv.includes("--is-test") || process.env.YTDOWNLOADER_TEST === "true",
 	windowsStore: process.windowsStore,
 	__dirname: path.join(__dirname, "html"),
 });

--- a/src/compressor.js
+++ b/src/compressor.js
@@ -278,7 +278,10 @@ async function compressVideo(file, settings, itemId, outputPath) {
 	console.log("Command: " + args.join(" "));
 
 	return new Promise((resolve, reject) => {
-		const child = spawn(ffmpeg, args);
+		const isTestMode = Boolean(window.electronAPI && window.electronAPI.isTest);
+		const mockSpawn = isTestMode ? (window.__mockSpawn || window.__mockFfmpeg) : null;
+		const spawnFn = mockSpawn || spawn;
+		const child = spawnFn(ffmpeg, args);
 
 		activeProcesses.add(child);
 		child.on("exit", () => {
@@ -936,6 +939,7 @@ function timeToSeconds(timeStr) {
 }
 
 function getFfmpegPath() {
+	if (window.electronAPI && window.electronAPI.isTest && (window.__mockYtDlp || window.__mockSpawn || window.__mockFfmpeg)) return "ffmpeg";
 	if (
 		env &&
 		env.YTDOWNLOADER_FFMPEG_PATH &&
@@ -1027,7 +1031,10 @@ function getFfprobePath() {
 function getVideoDuration(filePath) {
 	const ffprobe = getFfprobePath();
 	return new Promise((resolve, reject) => {
-		const child = spawn(ffprobe, [
+		const isTestMode = Boolean(window.electronAPI && window.electronAPI.isTest);
+		const mockSpawn = isTestMode ? (window.__mockSpawn || window.__mockFfmpeg) : null;
+		const spawnFn = mockSpawn || spawn;
+		const child = spawnFn(ffprobe, [
 			"-v",
 			"error",
 			"-show_entries",
@@ -1036,6 +1043,7 @@ function getVideoDuration(filePath) {
 			"default=noprint_wrappers=1:nokey=1",
 			filePath,
 		]);
+
 		let output = "";
 		const timeout = setTimeout(() => {
 			child.kill();
@@ -1067,7 +1075,10 @@ function getVideoDuration(filePath) {
 function getVideoCodec(filePath) {
 	const ffprobe = getFfprobePath();
 	return new Promise((resolve) => {
-		const child = spawn(ffprobe, [
+		const isTestMode = Boolean(window.electronAPI && window.electronAPI.isTest);
+		const mockSpawn = isTestMode ? (window.__mockSpawn || window.__mockFfmpeg) : null;
+		const spawnFn = mockSpawn || spawn;
+		const child = spawnFn(ffprobe, [
 			"-v",
 			"error",
 			"-select_streams",

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -115,8 +115,10 @@ const playlistDownloader = {
 
 	loadInitialConfig() {
 		// yt-dlp path
-		this.state.ytDlpPath = localStorage.getItem("ytdlp");
-		this.state.ytDlpWrap = new YTDlpWrap(this.state.ytDlpPath);
+		const isTestMode = Boolean(window.electronAPI && window.electronAPI.isTest);
+		const mockYtDlp = isTestMode ? window.__mockYtDlp : null;
+		this.state.ytDlpPath = mockYtDlp ? "mock-ytdlp" : localStorage.getItem("ytdlp");
+		this.state.ytDlpWrap = mockYtDlp || new YTDlpWrap(this.state.ytDlpPath);
 
 		const defaultDownloadsDir = path.join(os.homedir(), "Downloads");
 		let preferredDir =
@@ -872,6 +874,7 @@ const playlistDownloader = {
 	},
 
 	getFfmpegPath() {
+		if (window.electronAPI && window.electronAPI.isTest && window.__mockYtDlp) return "ffmpeg";
 		if (
 			env &&
 			env.YTDOWNLOADER_FFMPEG_PATH &&
@@ -908,6 +911,7 @@ const playlistDownloader = {
 	},
 
 	getJsRuntimePath() {
+		if (window.electronAPI && window.electronAPI.isTest && window.__mockYtDlp) return "";
 		{
 			const exeName = "node";
 
@@ -966,4 +970,5 @@ const playlistDownloader = {
 	},
 };
 
+window.playlistDownloader = playlistDownloader;
 playlistDownloader.init();

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -183,11 +183,13 @@ class YtDownloaderApp {
 		this._configureAutoUpdate();
 
 		try {
-			this.state.ytDlpPath = await this._findOrDownloadYtDlp();
-			this.state.ytDlp = new YTDlpWrap(this.state.ytDlpPath);
-			this.state.ffmpegPath = await this._findFfmpeg();
+			const isTestMode = Boolean(window.electronAPI && window.electronAPI.isTest);
+			const mockYtDlp = isTestMode ? window.__mockYtDlp : null;
+			this.state.ytDlpPath = mockYtDlp ? "mock-ytdlp" : await this._findOrDownloadYtDlp();
+			this.state.ytDlp = mockYtDlp || new YTDlpWrap(this.state.ytDlpPath);
+			this.state.ffmpegPath = mockYtDlp ? "ffmpeg" : await this._findFfmpeg();
 			this._ensureFfmpegLibsLoadable(this.state.ffmpegPath);
-			this.state.jsRuntimePath = await this._getJsRuntimePath();
+			this.state.jsRuntimePath = mockYtDlp ? "" : await this._getJsRuntimePath();
 
 			console.log("yt-dlp path:", this.state.ytDlpPath);
 			console.log("ffmpeg path:", this.state.ffmpegPath);
@@ -2625,5 +2627,6 @@ class YtDownloaderApp {
 // --- Application Entry Point ---
 document.addEventListener("DOMContentLoaded", () => {
 	const app = new YtDownloaderApp();
+	window.app = app;
 	app.initialize();
 });

--- a/tests/compressor-page-compression.spec.js
+++ b/tests/compressor-page-compression.spec.js
@@ -1,0 +1,240 @@
+const { test, expect } = require("@playwright/test");
+const os = require("os");
+const fs = require("fs");
+const path = require("path");
+const {
+	launchApp,
+	getExecutedCommands,
+	clearExecutedCommands,
+} = require("./helpers/electronApp");
+
+async function attachTestFile(page, fileName = "test_video.mp4") {
+	const tempFilePath = path.join(os.tmpdir(), fileName);
+	if (!fs.existsSync(tempFilePath)) {
+		fs.writeFileSync(tempFilePath, "mock video content");
+	}
+	await page.setInputFiles("#fileInput", tempFilePath);
+}
+
+async function waitForFfmpegCommand(page) {
+	await page.waitForFunction(() => {
+		const cmds = window.__executedCommands || [];
+		return cmds.some((cmd) => cmd.includes("-i") && !cmd.includes("-show_entries"));
+	});
+}
+
+async function getFfmpegCommands(page) {
+	const commands = await getExecutedCommands(page);
+	return commands.filter(
+		(cmd) => cmd.includes("-hide_banner") || (cmd.includes("-i") && !cmd.includes("-show_entries")),
+	);
+}
+
+test.describe("Compressor Page Tests", () => {
+	let electronApp;
+	let page;
+
+	test.beforeEach(async () => {
+		const res = await launchApp({}, undefined, "html/compressor.html");
+		electronApp = res.app;
+		page = res.page;
+	});
+
+	test.afterEach(async () => {
+		if (electronApp) {
+			await electronApp.close();
+		}
+	});
+
+	test("small file quality preset generates correct -crf 28 argument", async () => {
+		await attachTestFile(page);
+
+		// Select small file preset (CRF 28)
+		await page.click('button[data-quality="small"]');
+
+		await clearExecutedCommands(page);
+
+		await page.click("#compress-btn");
+		await waitForFfmpegCommand(page);
+
+		const commands = await getFfmpegCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+		const ffmpegCmd = commands[commands.length - 1];
+
+		expect(ffmpegCmd).toContain("-c:v");
+		expect(ffmpegCmd).toContain("libx264");
+		expect(ffmpegCmd).toContain("-crf");
+		expect(ffmpegCmd).toContain("28");
+		expect(ffmpegCmd).toContain("-preset");
+		expect(ffmpegCmd).toContain("medium");
+		expect(ffmpegCmd).toContain("-c:a");
+		expect(ffmpegCmd).toContain("copy");
+	});
+
+	test("balanced quality preset generates default -crf 23 argument", async () => {
+		await attachTestFile(page);
+
+		// Select balanced preset (CRF 23)
+		await page.click('button[data-quality="balanced"]');
+
+		await clearExecutedCommands(page);
+
+		await page.click("#compress-btn");
+		await waitForFfmpegCommand(page);
+
+		const commands = await getFfmpegCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+		const ffmpegCmd = commands[commands.length - 1];
+
+		expect(ffmpegCmd).toContain("-crf");
+		const crfIndex = ffmpegCmd.indexOf("-crf");
+		expect(ffmpegCmd[crfIndex + 1]).toBe("23");
+	});
+
+	test("high quality preset generates -crf 18 argument", async () => {
+		await attachTestFile(page);
+
+		// Select high quality preset (CRF 18)
+		await page.click('button[data-quality="high"]');
+
+		await clearExecutedCommands(page);
+
+		await page.click("#compress-btn");
+		await waitForFfmpegCommand(page);
+
+		const commands = await getFfmpegCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+		const ffmpegCmd = commands[commands.length - 1];
+
+		expect(ffmpegCmd).toContain("-crf");
+		const crfIndex = ffmpegCmd.indexOf("-crf");
+		expect(ffmpegCmd[crfIndex + 1]).toBe("18");
+	});
+
+	test("custom CRF slider setting is passed to ffmpeg command", async () => {
+		await attachTestFile(page);
+
+		await page.click('button[data-quality="custom"]');
+
+		// In compressor.js: crf = 69 - sliderVal. Setting slider to 39 gives crf = 30.
+		await page.evaluate(() => {
+			const slider = document.getElementById("quality-slider");
+			slider.value = "39";
+			slider.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+
+		await clearExecutedCommands(page);
+
+		await page.click("#compress-btn");
+		await waitForFfmpegCommand(page);
+
+		const commands = await getFfmpegCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+		const ffmpegCmd = commands[commands.length - 1];
+
+		expect(ffmpegCmd).toContain("-crf");
+		const crfIndex = ffmpegCmd.indexOf("-crf");
+		expect(ffmpegCmd[crfIndex + 1]).toBe("30");
+	});
+
+	test("target size preset calculates and passes bitrate -b:v to ffmpeg command", async () => {
+		await attachTestFile(page);
+
+		await page.click('button[data-quality="target-size"]');
+
+		// Set target size input to 10 MB
+		await page.fill("#target-size-input", "10");
+
+		await clearExecutedCommands(page);
+
+		await page.click("#compress-btn");
+		await waitForFfmpegCommand(page);
+
+		const commands = await getFfmpegCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+		const ffmpegCmd = commands[commands.length - 1];
+
+		expect(ffmpegCmd).toContain("-b:v");
+		const bvIndex = ffmpegCmd.indexOf("-b:v");
+		expect(ffmpegCmd[bvIndex + 1]).toMatch(/^\d+$/);
+	});
+
+	test("x265 encoder selection uses libx265 codec in ffmpeg command", async () => {
+		await attachTestFile(page);
+
+		await page.click('button[data-quality="balanced"]');
+		await page.selectOption("#encoder", "x265");
+
+		await clearExecutedCommands(page);
+
+		await page.click("#compress-btn");
+		await waitForFfmpegCommand(page);
+
+		const commands = await getFfmpegCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+		const ffmpegCmd = commands[commands.length - 1];
+
+		expect(ffmpegCmd).toContain("-c:v");
+		const cvIndex = ffmpegCmd.indexOf("-c:v");
+		expect(ffmpegCmd[cvIndex + 1]).toBe("libx265");
+	});
+
+	test("compression speed preset passes -preset flag to ffmpeg command", async () => {
+		await attachTestFile(page);
+
+		await page.click('button[data-quality="balanced"]');
+		await page.selectOption("#compression-speed", "slow");
+
+		await clearExecutedCommands(page);
+
+		await page.click("#compress-btn");
+		await waitForFfmpegCommand(page);
+
+		const commands = await getFfmpegCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+		const ffmpegCmd = commands[commands.length - 1];
+
+		expect(ffmpegCmd).toContain("-preset");
+		const presetIndex = ffmpegCmd.indexOf("-preset");
+		expect(ffmpegCmd[presetIndex + 1]).toBe("slow");
+	});
+
+	test("audio format selection passes -c:a copy to ffmpeg command", async () => {
+		await attachTestFile(page);
+
+		await page.click('button[data-quality="balanced"]');
+		await page.selectOption("#audio-format", "copy");
+
+		await clearExecutedCommands(page);
+
+		await page.click("#compress-btn");
+		await waitForFfmpegCommand(page);
+
+		const commands = await getFfmpegCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+		const ffmpegCmd = commands[commands.length - 1];
+
+		expect(ffmpegCmd).toContain("-c:a");
+		const caIndex = ffmpegCmd.indexOf("-c:a");
+		expect(ffmpegCmd[caIndex + 1]).toBe("copy");
+	});
+
+	test("file extension selection sets output format extension", async () => {
+		await attachTestFile(page);
+
+		await page.click('button[data-quality="balanced"]');
+		await page.selectOption("#file_extension", "mkv");
+
+		await clearExecutedCommands(page);
+
+		await page.click("#compress-btn");
+		await waitForFfmpegCommand(page);
+
+		const commands = await getFfmpegCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+		const ffmpegCmd = commands[commands.length - 1];
+
+		const outputPath = ffmpegCmd[ffmpegCmd.length - 1];
+		expect(outputPath.endsWith(".mkv")).toBe(true);
+	});
+});

--- a/tests/helpers/electronApp.js
+++ b/tests/helpers/electronApp.js
@@ -1,0 +1,257 @@
+const { _electron: electron } = require("@playwright/test");
+const path = require("path");
+const os = require("os");
+const fs = require("fs");
+const crypto = require("crypto");
+
+const DEFAULT_MOCK_METADATA = {
+	id: "dQw4w9WgXcQ",
+	title: "Test YouTube Video Title",
+	channel: "Test Channel Name",
+	thumbnail: "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+	duration: 213,
+	extractor_key: "Youtube",
+	url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+	webpage_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+	formats: [
+		{
+			format_id: "137",
+			ext: "mp4",
+			height: 1080,
+			fps: 30,
+			vcodec: "avc1.640028",
+			acodec: "none",
+			filesize: 50000000,
+		},
+		{
+			format_id: "248",
+			ext: "webm",
+			height: 1080,
+			fps: 30,
+			vcodec: "vp9",
+			acodec: "none",
+			filesize: 45000000,
+		},
+		{
+			format_id: "22",
+			ext: "mp4",
+			height: 720,
+			fps: 30,
+			vcodec: "avc1.47001f",
+			acodec: "mp4a.40.2",
+			filesize: 25000000,
+		},
+		{
+			format_id: "140",
+			ext: "m4a",
+			format_note: "medium",
+			vcodec: "none",
+			acodec: "mp4a.40.2",
+			filesize: 3000000,
+		},
+		{
+			format_id: "251",
+			ext: "webm",
+			format_note: "tiny",
+			vcodec: "none",
+			acodec: "opus",
+			filesize: 3500000,
+		},
+	],
+};
+
+/**
+ * Launches the Electron app headlessly with pre-injected yt-dlp/ffmpeg mocking script so initial config uses the mock.
+ */
+async function launchApp(customLocalStorage = {}, customMetadata = DEFAULT_MOCK_METADATA, targetPage = null) {
+	const testUserDataDir = path.join(os.tmpdir(), `ytdownloader-test-userdata-${crypto.randomUUID()}`);
+	if (!fs.existsSync(testUserDataDir)) {
+		fs.mkdirSync(testUserDataDir, { recursive: true });
+	}
+
+	const app = await electron.launch({
+		args: [
+			path.join(__dirname, "../../main.js"),
+			`--user-data-dir=${testUserDataDir}`,
+			"--is-test",
+			"--headless",
+			"--no-sandbox",
+			"--disable-gpu",
+		],
+		env: {
+			...process.env,
+			NODE_ENV: "test",
+			YTDOWNLOADER_TEST: "true",
+		},
+	});
+
+	const page = await app.firstWindow();
+
+	// Inject mocking before DOMContentLoaded so app.initialize() / compressor.js picks it up immediately
+	await page.addInitScript((meta) => {
+		window.__executedCommands = [];
+		window.__mockMetadata = meta;
+
+		const createMockProcess = (args) => {
+			window.__executedCommands.push(args);
+			const callbacks = {};
+			const stdoutCbs = [];
+			const stderrCbs = [];
+
+			const procWrapper = {
+				ytDlpProcess: {
+					spawnargs: args,
+					stdout: {
+						on: (event, cb) => {
+							if (event === "data") stdoutCbs.push(cb);
+						},
+					},
+					stderr: {
+						on: (event, cb) => {
+							if (event === "data") stderrCbs.push(cb);
+						},
+					},
+					kill: () => {},
+					killed: false,
+					pid: 99999,
+				},
+				on: (event, cb) => {
+					callbacks[event] = callbacks[event] || [];
+					callbacks[event].push(cb);
+					return procWrapper;
+				},
+				once: (event, cb) => {
+					callbacks[event] = callbacks[event] || [];
+					callbacks[event].push(cb);
+					return procWrapper;
+				},
+				kill: () => {},
+				killed: false,
+			};
+
+			setTimeout(() => {
+				if (args.includes("-j")) {
+					const jsonStr = JSON.stringify(window.__mockMetadata);
+					stdoutCbs.forEach((cb) => cb(jsonStr));
+					(callbacks["close"] || []).forEach((cb) => cb(0));
+				} else {
+					(callbacks["progress"] || []).forEach((cb) =>
+						cb({ percent: 100 }),
+					);
+					(callbacks["ytDlpEvent"] || []).forEach((cb) => cb());
+					(callbacks["close"] || []).forEach((cb) => cb(0));
+				}
+			}, 10);
+
+			return procWrapper;
+		};
+
+		window.__mockYtDlp = {
+			exec: (args) => createMockProcess(args),
+			execPromise: async () => JSON.stringify(window.__mockMetadata),
+		};
+
+		// Mock spawn function for FFmpeg / FFprobe child processes
+		const mockSpawnFn = (cmd, args = []) => {
+			window.__executedCommands.push(args);
+			const callbacks = {};
+			const stdoutCbs = [];
+			const stderrCbs = [];
+
+			const childMock = {
+				stdout: {
+					on: (event, cb) => {
+						if (event === "data") stdoutCbs.push(cb);
+					},
+				},
+				stderr: {
+					on: (event, cb) => {
+						if (event === "data") stderrCbs.push(cb);
+					},
+				},
+				stdin: {
+					write: () => {},
+				},
+				on: (event, cb) => {
+					callbacks[event] = callbacks[event] || [];
+					callbacks[event].push(cb);
+					return childMock;
+				},
+				once: (event, cb) => {
+					callbacks[event] = callbacks[event] || [];
+					callbacks[event].push(cb);
+					return childMock;
+				},
+				kill: () => {},
+				killed: false,
+				pid: 88888,
+			};
+
+			setTimeout(() => {
+				if (args.includes("format=duration")) {
+					stdoutCbs.forEach((cb) => cb("60.0\n"));
+				} else if (args.includes("stream=codec_name")) {
+					stdoutCbs.forEach((cb) => cb("h264\n"));
+				} else {
+					stderrCbs.forEach((cb) =>
+						cb(
+							"Duration: 00:01:00.00, start: 0.00, bitrate: 1000 kb/s\nframe=100 fps=30 q=23.0 size=1000kB time=00:00:30.00 bitrate=270.0kbits/s speed=1.5x",
+						),
+					);
+				}
+				(callbacks["exit"] || []).forEach((cb) => cb(0));
+				(callbacks["close"] || []).forEach((cb) => cb(0));
+			}, 10);
+
+			return childMock;
+		};
+
+		window.__mockSpawn = mockSpawnFn;
+	}, customMetadata);
+
+	// Apply localStorage preferences if provided
+	if (Object.keys(customLocalStorage).length > 0) {
+		await page.evaluate((storage) => {
+			for (const [key, val] of Object.entries(storage)) {
+				localStorage.setItem(key, String(val));
+			}
+		}, customLocalStorage);
+	}
+
+	if (targetPage) {
+		await Promise.all([
+			page.waitForNavigation({ waitUntil: "domcontentloaded" }),
+			page.evaluate((relPath) => {
+				window.electronAPI.ipcRenderer.send("load-win", relPath);
+			}, targetPage),
+		]);
+	} else {
+		await page.reload();
+		await page.waitForLoadState("domcontentloaded");
+	}
+
+	return { app, page };
+}
+
+/**
+ * Gets array of commands executed by yt-dlp/ffmpeg in page context.
+ */
+async function getExecutedCommands(page) {
+	return await page.evaluate(() => window.__executedCommands || []);
+}
+
+/**
+ * Clears recorded executed commands.
+ */
+async function clearExecutedCommands(page) {
+	await page.evaluate(() => {
+		window.__executedCommands = [];
+	});
+}
+
+module.exports = {
+	launchApp,
+	getExecutedCommands,
+	clearExecutedCommands,
+	DEFAULT_MOCK_METADATA,
+};

--- a/tests/main-page-downloads.spec.js
+++ b/tests/main-page-downloads.spec.js
@@ -1,0 +1,171 @@
+const { test, expect } = require("@playwright/test");
+const {
+	launchApp,
+	getExecutedCommands,
+	clearExecutedCommands,
+} = require("./helpers/electronApp");
+
+async function waitForInfoPanel(page) {
+	await page.waitForFunction(() => {
+		const el = document.getElementById("hidden");
+		return el && el.style.display === "inline-block";
+	});
+}
+
+async function triggerClick(page, elementId) {
+	await page.evaluate((id) => {
+		const el = document.getElementById(id);
+		if (el) el.click();
+	}, elementId);
+}
+
+test.describe("Main Page Download Tests", () => {
+	let electronApp;
+	let page;
+
+	test.beforeEach(async () => {
+		const res = await launchApp();
+		electronApp = res.app;
+		page = res.page;
+	});
+
+	test.afterEach(async () => {
+		if (electronApp) {
+			await electronApp.close();
+		}
+	});
+
+	test("video download produces correct yt-dlp command", async () => {
+		const testUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+		await page.evaluate((url) => {
+			window.electronAPI.clipboard.writeText(url);
+		}, testUrl);
+
+		// Click paste button to fetch info
+		await page.click("#pasteUrl");
+
+		// Wait for info panel to be populated and displayed
+		await waitForInfoPanel(page);
+
+		await clearExecutedCommands(page);
+
+		// Trigger "Download Video"
+		await triggerClick(page, "videoDownload");
+
+		await page.waitForFunction(() => {
+			const cmds = window.__executedCommands || [];
+			return cmds.some((cmd) => cmd.includes("-f"));
+		});
+
+		// Retrieve executed commands
+		const commands = await getExecutedCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+
+		// Find download command (the one with -f flag)
+		const downloadCmd = commands.find((cmd) => cmd.includes("-f"));
+		expect(downloadCmd).toBeDefined();
+
+		// Verify command structure
+		expect(downloadCmd).toContain("-f");
+		expect(downloadCmd).toContain("-P");
+		expect(downloadCmd).toContain("-o");
+		expect(downloadCmd).toContain("--ffmpeg-location");
+		expect(downloadCmd.join(" ")).toContain("dQw4w9WgXcQ");
+	});
+
+	test("audio download produces correct yt-dlp command", async () => {
+		const testUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+		await page.evaluate((url) => {
+			window.electronAPI.clipboard.writeText(url);
+		}, testUrl);
+
+		// Fetch info
+		await page.click("#pasteUrl");
+		await waitForInfoPanel(page);
+
+		// Switch to Audio tab
+		await page.evaluate(() => document.getElementById("audioToggle").click());
+
+		// Ensure audio format select has a valid option value selected
+		await page.evaluate(() => {
+			const sel = document.getElementById("audioFormatSelect");
+			if (!sel.value && sel.options.length > 0) {
+				sel.value = sel.options[0].value;
+			}
+		});
+
+		await clearExecutedCommands(page);
+
+		// Trigger "Download Audio"
+		await triggerClick(page, "audioDownload");
+
+		await page.waitForFunction(() => {
+			const cmds = window.__executedCommands || [];
+			return cmds.some((cmd) => cmd.includes("-f"));
+		});
+
+		const commands = await getExecutedCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+
+		const downloadCmd = commands.find((cmd) => cmd.includes("-f"));
+		expect(downloadCmd).toBeDefined();
+
+		// Verify audio download args
+		expect(downloadCmd).toContain("-f");
+		expect(downloadCmd).toContain("-P");
+		expect(downloadCmd).toContain("-o");
+		expect(downloadCmd.join(" ")).toContain("dQw4w9WgXcQ");
+	});
+
+	test("audio extract produces correct yt-dlp command", async () => {
+		const testUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+		await page.evaluate((url) => {
+			window.electronAPI.clipboard.writeText(url);
+		}, testUrl);
+
+		// Fetch info
+		await page.click("#pasteUrl");
+		await waitForInfoPanel(page);
+
+		// Switch to Audio tab
+		await page.evaluate(() => document.getElementById("audioToggle").click());
+
+		// Select extract format mp3
+		await page.evaluate(() => {
+			const sel = document.getElementById("extractSelection");
+			if (sel) {
+				sel.value = "mp3";
+				sel.dispatchEvent(new Event("change", { bubbles: true }));
+			}
+		});
+
+		await clearExecutedCommands(page);
+
+		// Trigger Extract
+		await triggerClick(page, "extractBtn");
+
+		await page.waitForFunction(() => {
+			const cmds = window.__executedCommands || [];
+			return cmds.some((cmd) => cmd.includes("-x"));
+		});
+
+		const commands = await getExecutedCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+
+		const extractCmd = commands.find((cmd) => cmd.includes("-x"));
+		expect(extractCmd).toBeDefined();
+
+		// Verify extract args
+		expect(extractCmd).toContain("-x");
+		expect(extractCmd).toContain("--audio-format");
+		expect(extractCmd).toContain("mp3");
+		expect(extractCmd).toContain("--audio-quality");
+		expect(extractCmd).toContain("--embed-thumbnail");
+		expect(extractCmd).toContain("-P");
+		expect(extractCmd).toContain("-o");
+		expect(extractCmd.some((arg) => arg.includes("dQw4w9WgXcQ"))).toBe(true);
+	});
+});

--- a/tests/playlist-page-downloads.spec.js
+++ b/tests/playlist-page-downloads.spec.js
@@ -1,0 +1,216 @@
+const { test, expect } = require("@playwright/test");
+const {
+	launchApp,
+	getExecutedCommands,
+	clearExecutedCommands,
+} = require("./helpers/electronApp");
+
+async function waitForPlaylistOptions(page) {
+	await page.waitForFunction(() => {
+		const options = document.getElementById("options");
+		return options && options.style.display === "block";
+	});
+}
+
+async function triggerClick(page, elementId) {
+	await page.evaluate((id) => {
+		const el = document.getElementById(id);
+		if (el) el.click();
+	}, elementId);
+}
+
+test.describe("Playlist Page Download Tests", () => {
+	let electronApp;
+	let page;
+
+	test.beforeEach(async () => {
+		const res = await launchApp({}, undefined, "html/playlist.html");
+		electronApp = res.app;
+		page = res.page;
+	});
+
+	test.afterEach(async () => {
+		if (electronApp) {
+			await electronApp.close();
+		}
+	});
+
+	test("playlist video download produces correct yt-dlp command", async () => {
+		const playlistUrl = "https://www.youtube.com/playlist?list=PL123456789";
+
+		await page.evaluate((url) => {
+			window.electronAPI.clipboard.writeText(url);
+		}, playlistUrl);
+
+		await page.click("#pasteLink");
+		await waitForPlaylistOptions(page);
+
+		await page.selectOption("#select", "1080");
+		await page.selectOption("#videoTypeSelect", "mp4");
+
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "download");
+
+		const commands = await getExecutedCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+
+		const downloadCmd = commands[commands.length - 1];
+		expect(downloadCmd).toContain("--yes-playlist");
+		expect(downloadCmd).toContain("-f");
+		expect(downloadCmd).toContain("-o");
+		expect(downloadCmd).toContain("--ffmpeg-location");
+		expect(downloadCmd.join(" ")).toContain("PL123456789");
+	});
+
+	test("playlist audio download produces correct yt-dlp command", async () => {
+		const playlistUrl = "https://www.youtube.com/playlist?list=PL123456789";
+
+		await page.evaluate((url) => {
+			window.electronAPI.clipboard.writeText(url);
+		}, playlistUrl);
+
+		await page.click("#pasteLink");
+		await waitForPlaylistOptions(page);
+
+		await triggerClick(page, "audioToggle");
+
+		await page.selectOption("#audioSelect", "mp3");
+		await page.selectOption("#audioQualitySelect", "0");
+
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "audioDownload");
+
+		const commands = await getExecutedCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+
+		const downloadCmd = commands[commands.length - 1];
+		expect(downloadCmd).toContain("--yes-playlist");
+		expect(downloadCmd).toContain("-x");
+		expect(downloadCmd).toContain("--audio-format");
+		expect(downloadCmd).toContain("mp3");
+		expect(downloadCmd).toContain("--audio-quality");
+		expect(downloadCmd).toContain("0");
+		expect(downloadCmd).toContain("--embed-thumbnail");
+		expect(downloadCmd.join(" ")).toContain("PL123456789");
+	});
+
+	test("download thumbnails produces correct yt-dlp command", async () => {
+		const playlistUrl = "https://www.youtube.com/playlist?list=PL123456789";
+
+		await page.evaluate((url) => {
+			window.electronAPI.clipboard.writeText(url);
+		}, playlistUrl);
+
+		await page.click("#pasteLink");
+		await waitForPlaylistOptions(page);
+
+		await triggerClick(page, "advancedToggle");
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "downloadThumbnails");
+
+		await page.waitForFunction(() => {
+			const cmds = window.__executedCommands || [];
+			return cmds.some((cmd) => cmd.includes("--write-thumbnail"));
+		});
+
+		const commands = await getExecutedCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+
+		const downloadCmd = commands[commands.length - 1];
+		expect(downloadCmd).toContain("--write-thumbnail");
+		expect(downloadCmd).toContain("--convert-thumbnails");
+		expect(downloadCmd).toContain("png");
+		expect(downloadCmd).toContain("--skip-download");
+		expect(downloadCmd.join(" ")).toContain("PL123456789");
+	});
+
+	test("save video links produces correct yt-dlp command", async () => {
+		const playlistUrl = "https://www.youtube.com/playlist?list=PL123456789";
+
+		await page.evaluate((url) => {
+			window.electronAPI.clipboard.writeText(url);
+		}, playlistUrl);
+
+		await page.click("#pasteLink");
+		await waitForPlaylistOptions(page);
+
+		await triggerClick(page, "advancedToggle");
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "saveLinks");
+
+		await page.waitForFunction(() => {
+			const cmds = window.__executedCommands || [];
+			return cmds.some((cmd) => cmd.includes("webpage_url"));
+		});
+
+		const commands = await getExecutedCommands(page);
+		expect(commands.length).toBeGreaterThan(0);
+
+		const downloadCmd = commands[commands.length - 1];
+		expect(downloadCmd).toContain("--skip-download");
+		expect(downloadCmd).toContain("--print-to-file");
+		expect(downloadCmd).toContain("webpage_url");
+		expect(downloadCmd.join(" ")).toContain("PL123456789");
+	});
+
+	test("playlist index range selection is passed to -I argument", async () => {
+		const playlistUrl = "https://www.youtube.com/playlist?list=PL123456789";
+
+		await page.evaluate((url) => {
+			window.electronAPI.clipboard.writeText(url);
+		}, playlistUrl);
+
+		await page.click("#pasteLink");
+		await waitForPlaylistOptions(page);
+
+		await triggerClick(page, "advancedToggle");
+
+		await page.fill("#playlistIndex", "2");
+		await page.fill("#playlistEnd", "10");
+
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "download");
+
+		const commands = await getExecutedCommands(page);
+		const downloadCmd = commands[commands.length - 1];
+
+		expect(downloadCmd).toContain("-I");
+		const rangeIndex = downloadCmd.indexOf("-I");
+		expect(downloadCmd[rangeIndex + 1]).toBe("2:10");
+	});
+
+	test("download subtitles option adds subtitle flags to command", async () => {
+		const playlistUrl = "https://www.youtube.com/playlist?list=PL123456789";
+
+		await page.evaluate((url) => {
+			window.electronAPI.clipboard.writeText(url);
+		}, playlistUrl);
+
+		await page.click("#pasteLink");
+		await waitForPlaylistOptions(page);
+
+		await triggerClick(page, "advancedToggle");
+
+		await page.check("#subChecked");
+
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "download");
+
+		const commands = await getExecutedCommands(page);
+		const downloadCmd = commands[commands.length - 1];
+
+		expect(downloadCmd).toContain("--write-subs");
+		expect(downloadCmd).toContain("--sub-format");
+		expect(downloadCmd).toContain("srt/best");
+		expect(downloadCmd).toContain("--convert-subs");
+		expect(downloadCmd).toContain("srt");
+		expect(downloadCmd).toContain("--sub-langs");
+		expect(downloadCmd).toContain("all");
+	});
+});

--- a/tests/playlist-preferences-integration.spec.js
+++ b/tests/playlist-preferences-integration.spec.js
@@ -1,0 +1,144 @@
+const { test, expect } = require("@playwright/test");
+const os = require("os");
+const fs = require("fs");
+const path = require("path");
+const {
+	launchApp,
+	getExecutedCommands,
+	clearExecutedCommands,
+} = require("./helpers/electronApp");
+
+async function waitForPlaylistOptions(page) {
+	await page.waitForFunction(() => {
+		const options = document.getElementById("options");
+		return options && options.style.display === "block";
+	});
+}
+
+async function triggerClick(page, elementId) {
+	await page.evaluate((id) => {
+		const el = document.getElementById(id);
+		if (el) el.click();
+	}, elementId);
+}
+
+test.describe("Playlist Preferences Integration Tests", () => {
+	let electronApp;
+	let page;
+
+	test.afterEach(async () => {
+		if (electronApp) {
+			await electronApp.close();
+		}
+	});
+
+	test("download location and output templates are reflected in playlist -o argument", async () => {
+		const customDir = path.join(os.tmpdir(), "ytPlaylistTestDir");
+		if (!fs.existsSync(customDir)) {
+			fs.mkdirSync(customDir, { recursive: true });
+		}
+
+		const customFolder = "%(playlist_title)s_folder";
+		const customFile = "%(playlist_index)s_%(title)s_custom.%(ext)s";
+
+		const res = await launchApp({
+			downloadPath: customDir,
+			foldernameFormat: customFolder,
+			filenameFormat: customFile,
+		}, undefined, "html/playlist.html");
+
+		electronApp = res.app;
+		page = res.page;
+
+		const playlistUrl = "https://www.youtube.com/playlist?list=PL123456789";
+
+		await page.evaluate((url) => {
+			window.electronAPI.clipboard.writeText(url);
+		}, playlistUrl);
+
+		await page.click("#pasteLink");
+		await waitForPlaylistOptions(page);
+
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "download");
+
+		const commands = await getExecutedCommands(page);
+		const downloadCmd = commands[commands.length - 1];
+
+		expect(downloadCmd).toBeDefined();
+		const oIndex = downloadCmd.indexOf("-o");
+		expect(oIndex).not.toBe(-1);
+
+		const expectedOutputPath = path.join(customDir, customFolder, customFile);
+		expect(downloadCmd[oIndex + 1]).toBe(expectedOutputPath);
+	});
+
+	test("preferred video and audio quality defaults are selected in UI dropdowns", async () => {
+		const res = await launchApp({
+			preferredVideoQuality: "720",
+			preferredAudioQuality: "flac",
+		}, undefined, "html/playlist.html");
+
+		electronApp = res.app;
+		page = res.page;
+
+		const selectedVideo = await page.$eval("#select", (el) => el.value);
+		expect(selectedVideo).toBe("720");
+
+		const selectedAudio = await page.$eval("#audioSelect", (el) => el.value);
+		expect(selectedAudio).toBe("flac");
+	});
+
+	test("cookies preference is included in playlist yt-dlp command", async () => {
+		const res = await launchApp({
+			cookieSource: "browser",
+			browser: "chrome",
+		}, undefined, "html/playlist.html");
+
+		electronApp = res.app;
+		page = res.page;
+
+		const playlistUrl = "https://www.youtube.com/playlist?list=PL123456789";
+		await page.evaluate((url) => window.electronAPI.clipboard.writeText(url), playlistUrl);
+
+		await page.click("#pasteLink");
+		await waitForPlaylistOptions(page);
+
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "download");
+
+		const commands = await getExecutedCommands(page);
+		const downloadCmd = commands[commands.length - 1];
+
+		expect(downloadCmd).toContain("--cookies-from-browser");
+		expect(downloadCmd).toContain("chrome");
+	});
+
+	test("proxy preference is included in playlist yt-dlp command", async () => {
+		const proxyUrl = "http://127.0.0.1:8080";
+		const res = await launchApp({
+			proxy: proxyUrl,
+		}, undefined, "html/playlist.html");
+
+		electronApp = res.app;
+		page = res.page;
+
+		const playlistUrl = "https://www.youtube.com/playlist?list=PL123456789";
+		await page.evaluate((url) => window.electronAPI.clipboard.writeText(url), playlistUrl);
+
+		await page.click("#pasteLink");
+		await waitForPlaylistOptions(page);
+
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "download");
+
+		const commands = await getExecutedCommands(page);
+		const downloadCmd = commands[commands.length - 1];
+
+		expect(downloadCmd).toContain("--proxy");
+		expect(downloadCmd).toContain(proxyUrl);
+	});
+});

--- a/tests/preferences-integration.spec.js
+++ b/tests/preferences-integration.spec.js
@@ -1,0 +1,266 @@
+const { test, expect } = require("@playwright/test");
+const os = require("os");
+const fs = require("fs");
+const path = require("path");
+const {
+	launchApp,
+	getExecutedCommands,
+	clearExecutedCommands,
+} = require("./helpers/electronApp");
+
+async function waitForInfoPanel(page) {
+	await page.waitForFunction(() => {
+		const el = document.getElementById("hidden");
+		return el && el.style.display === "inline-block";
+	});
+}
+
+async function triggerClick(page, elementId) {
+	await page.evaluate((id) => {
+		const el = document.getElementById(id);
+		if (el) el.click();
+	}, elementId);
+}
+
+test.describe("Preferences Integration Tests", () => {
+	let electronApp;
+	let page;
+
+	test.afterEach(async () => {
+		if (electronApp) {
+			await electronApp.close();
+		}
+	});
+
+	test("download location preference is used in yt-dlp command", async () => {
+		const customPath = path.join(os.tmpdir(), "ytDownloaderTestLocation");
+		if (!fs.existsSync(customPath)) {
+			fs.mkdirSync(customPath, { recursive: true });
+		}
+
+		const res = await launchApp({
+			downloadPath: customPath,
+		});
+		electronApp = res.app;
+		page = res.page;
+
+		const testUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+		await page.evaluate((url) => window.electronAPI.clipboard.writeText(url), testUrl);
+
+		await page.click("#pasteUrl");
+		await waitForInfoPanel(page);
+
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "videoDownload");
+
+		const commands = await getExecutedCommands(page);
+		const downloadCmd = commands.find((cmd) => cmd.includes("-f"));
+
+		expect(downloadCmd).toBeDefined();
+		const pathIndex = downloadCmd.indexOf("-P");
+		expect(pathIndex).not.toBe(-1);
+		expect(downloadCmd[pathIndex + 1]).toBe(customPath);
+	});
+
+	test("preferred video quality and codec select matching format", async () => {
+		const res = await launchApp({
+			preferredVideoQuality: "720",
+			preferredVideoCodec: "avc1",
+		});
+		electronApp = res.app;
+		page = res.page;
+
+		const testUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+		await page.evaluate((url) => window.electronAPI.clipboard.writeText(url), testUrl);
+
+		await page.click("#pasteUrl");
+		await waitForInfoPanel(page);
+
+		// Verify selected format in video dropdown is 720p (format_id 22)
+		const selectedFormat = await page.$eval(
+			"#videoFormatSelect",
+			(el) => el.value,
+		);
+		expect(selectedFormat).toContain("22");
+	});
+
+	test("showMoreFormats preference toggles format options in UI", async () => {
+		// Test showMoreFormats = false
+		const resHide = await launchApp({
+			showMoreFormats: "false",
+		});
+		electronApp = resHide.app;
+		page = resHide.page;
+
+		const testUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+		await page.evaluate((url) => window.electronAPI.clipboard.writeText(url), testUrl);
+
+		await page.click("#pasteUrl");
+		await waitForInfoPanel(page);
+
+		const formatValuesHide = await page.$$eval(
+			"#videoFormatSelect option",
+			(opts) => opts.map((o) => o.value),
+		);
+		// WebM format "248" should be excluded when showMoreFormats is false
+		const containsWebmHide = formatValuesHide.some((val) => val.includes("248"));
+		expect(containsWebmHide).toBe(false);
+
+		// Switch showMoreFormats = true via localStorage and reload page
+		await page.evaluate(() => localStorage.setItem("showMoreFormats", "true"));
+		await page.reload();
+
+		await page.evaluate((url) => window.electronAPI.clipboard.writeText(url), testUrl);
+		await page.click("#pasteUrl");
+		await waitForInfoPanel(page);
+
+		const formatValuesShow = await page.$$eval(
+			"#videoFormatSelect option",
+			(opts) => opts.map((o) => o.value),
+		);
+		// WebM format "248" should be included when showMoreFormats is true
+		const containsWebmShow = formatValuesShow.some((val) => val.includes("248"));
+		expect(containsWebmShow).toBe(true);
+	});
+
+	test("output templates preference is reflected in -o argument", async () => {
+		const customVidTemplate = "%(title)s_custom_video.%(ext)s";
+		const customAudTemplate = "%(title)s_custom_audio.%(ext)s";
+
+		const res = await launchApp({
+			filenameTemplateVideo: customVidTemplate,
+			filenameTemplateAudio: customAudTemplate,
+		});
+		electronApp = res.app;
+		page = res.page;
+
+		const testUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+		await page.evaluate((url) => window.electronAPI.clipboard.writeText(url), testUrl);
+
+		await page.click("#pasteUrl");
+		await waitForInfoPanel(page);
+
+		await clearExecutedCommands(page);
+
+		// Video Download
+		await triggerClick(page, "videoDownload");
+
+		let commands = await getExecutedCommands(page);
+		let downloadCmd = commands.find((cmd) => cmd.includes("-f"));
+
+		expect(downloadCmd).toBeDefined();
+		let oIndex = downloadCmd.indexOf("-o");
+		expect(oIndex).not.toBe(-1);
+		expect(downloadCmd[oIndex + 1]).toBe(customVidTemplate);
+
+		// Audio Download
+		await page.click("#audioToggle", { force: true });
+		await page.evaluate(() => {
+			const sel = document.getElementById("audioFormatSelect");
+			if (!sel.value && sel.options.length > 0) {
+				sel.value = sel.options[0].value;
+			}
+		});
+
+		await clearExecutedCommands(page);
+		await triggerClick(page, "audioDownload");
+
+		commands = await getExecutedCommands(page);
+		downloadCmd = commands.find((cmd) => cmd.includes("-f"));
+
+		expect(downloadCmd).toBeDefined();
+		oIndex = downloadCmd.indexOf("-o");
+		expect(oIndex).not.toBe(-1);
+		expect(downloadCmd[oIndex + 1]).toBe(customAudTemplate);
+	});
+
+	test("cookies preference is included in yt-dlp command", async () => {
+		// Test browser cookies
+		const resBrowser = await launchApp({
+			cookieSource: "browser",
+			browser: "firefox",
+		});
+		electronApp = resBrowser.app;
+		page = resBrowser.page;
+
+		const testUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+		await page.evaluate((url) => window.electronAPI.clipboard.writeText(url), testUrl);
+
+		await page.click("#pasteUrl");
+		await waitForInfoPanel(page);
+
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "videoDownload");
+
+		const commands = await getExecutedCommands(page);
+		const downloadCmd = commands.find((cmd) => cmd.includes("-f"));
+
+		expect(downloadCmd).toBeDefined();
+		expect(downloadCmd).toContain("--cookies-from-browser");
+		expect(downloadCmd).toContain("firefox");
+	});
+
+	test("proxy preference is included in yt-dlp command", async () => {
+		const proxyUrl = "http://127.0.0.1:8080";
+		const res = await launchApp({
+			proxy: proxyUrl,
+		});
+		electronApp = res.app;
+		page = res.page;
+
+		const testUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+		await page.evaluate((url) => window.electronAPI.clipboard.writeText(url), testUrl);
+
+		await page.click("#pasteUrl");
+		await waitForInfoPanel(page);
+
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "videoDownload");
+
+		await page.waitForFunction(() => {
+			const cmds = window.__executedCommands || [];
+			return cmds.some((cmd) => cmd.includes("-f"));
+		});
+
+		const commands = await getExecutedCommands(page);
+		const downloadCmd = commands.find((cmd) => cmd.includes("-f"));
+
+		expect(downloadCmd).toBeDefined();
+		expect(downloadCmd).toContain("--proxy");
+		expect(downloadCmd).toContain(proxyUrl);
+	});
+
+	test("custom yt-dlp options preference is appended to yt-dlp command", async () => {
+		const customArgs = "--no-check-certificates --geo-bypass";
+		const res = await launchApp({
+			customYtDlpArgs: customArgs,
+		});
+		electronApp = res.app;
+		page = res.page;
+
+		const testUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+		await page.evaluate((url) => window.electronAPI.clipboard.writeText(url), testUrl);
+
+		await page.click("#pasteUrl");
+		await waitForInfoPanel(page);
+
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "videoDownload");
+
+		await page.waitForFunction(() => {
+			const cmds = window.__executedCommands || [];
+			return cmds.some((cmd) => cmd.includes("-f"));
+		});
+
+		const commands = await getExecutedCommands(page);
+		const downloadCmd = commands.find((cmd) => cmd.includes("-f"));
+
+		expect(downloadCmd).toBeDefined();
+		expect(downloadCmd).toContain("--no-check-certificates");
+		expect(downloadCmd).toContain("--geo-bypass");
+	});
+});

--- a/tests/preferences-page.spec.js
+++ b/tests/preferences-page.spec.js
@@ -1,0 +1,181 @@
+const { test, expect } = require("@playwright/test");
+const { launchApp } = require("./helpers/electronApp");
+
+test.describe("Preferences Page Tests", () => {
+	let electronApp;
+	let page;
+
+	test.beforeEach(async () => {
+		const res = await launchApp({}, undefined, "html/preferences.html");
+		electronApp = res.app;
+		page = res.page;
+	});
+
+	test.afterEach(async () => {
+		if (electronApp) {
+			await electronApp.close();
+		}
+	});
+
+	test("tab navigation switches active tab content", async () => {
+		// General tab active by default
+		await expect(page.locator("#generalTab")).toHaveClass(/active/);
+
+		// Click Media Settings tab
+		await page.click('button[data-tab="media"]');
+		await expect(page.locator("#mediaTab")).toHaveClass(/active/);
+		await expect(page.locator("#generalTab")).not.toHaveClass(/active/);
+
+		// Click Advanced Tools tab
+		await page.click('button[data-tab="advanced"]');
+		await expect(page.locator("#advancedTab")).toHaveClass(/active/);
+		await expect(page.locator("#mediaTab")).not.toHaveClass(/active/);
+	});
+
+	test("settings search filters matching preferences items", async () => {
+		await page.fill("#settingsSearch", "proxy");
+
+		// Proxy setting item should not have .item-hidden
+		const proxyBox = page.locator("#proxyTitle").locator("..");
+		await expect(proxyBox).not.toHaveClass(/item-hidden/);
+
+		// Non-matching setting (e.g. max downloads) should gain .item-hidden
+		const maxDownloadsBox = page.locator("#maxTxt").locator("..");
+		await expect(maxDownloadsBox).toHaveClass(/item-hidden/);
+
+		// Clear search
+		await page.fill("#settingsSearch", "");
+		await expect(maxDownloadsBox).not.toHaveClass(/item-hidden/);
+	});
+
+	test("general settings update localStorage", async () => {
+		await page.selectOption("#select", "es-ES");
+		const savedLocale = await page.evaluate(() => localStorage.getItem("locale"));
+		expect(savedLocale).toBe("es-ES");
+
+		await page.fill("#maxDownloads", "8");
+		const savedMax = await page.evaluate(() => localStorage.getItem("maxActiveDownloads"));
+		expect(savedMax).toBe("8");
+
+		await page.evaluate(() => {
+			const cb = document.getElementById("closeToTray");
+			cb.checked = true;
+			cb.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		const savedTray = await page.evaluate(() => localStorage.getItem("closeToTray"));
+		expect(savedTray).toBe("true");
+
+		await page.evaluate(() => {
+			const cb = document.getElementById("autoUpdateDisabled");
+			cb.checked = true;
+			cb.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		const savedAutoUpdate = await page.evaluate(() => localStorage.getItem("autoUpdate"));
+		expect(savedAutoUpdate).toBe("false");
+	});
+
+	test("media settings preferences save to localStorage", async () => {
+		await page.click('button[data-tab="media"]');
+
+		await page.selectOption("#preferredVideoQuality", "1080");
+		const videoQuality = await page.evaluate(() => localStorage.getItem("preferredVideoQuality"));
+		expect(videoQuality).toBe("1080");
+
+		await page.selectOption("#preferredVideoCodec", "vp9");
+		const videoCodec = await page.evaluate(() => localStorage.getItem("preferredVideoCodec"));
+		expect(videoCodec).toBe("vp9");
+
+		await page.selectOption("#preferredAudioQuality", "flac");
+		const audioQuality = await page.evaluate(() => localStorage.getItem("preferredAudioQuality"));
+		expect(audioQuality).toBe("flac");
+
+		await page.evaluate(() => {
+			const cb = document.getElementById("showMoreFormats");
+			cb.checked = true;
+			cb.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		const showMore = await page.evaluate(() => localStorage.getItem("showMoreFormats"));
+		expect(showMore).toBe("true");
+	});
+
+	test("output templates inputs update localStorage and reset buttons restore defaults", async () => {
+		await page.click('button[data-tab="advanced"]');
+
+		// Audio filename template
+		await page.fill("#filenameTemplateAudio", "%(title)s_custom_audio.%(ext)s");
+		let savedAudioTpl = await page.evaluate(() => localStorage.getItem("filenameTemplateAudio"));
+		expect(savedAudioTpl).toBe("%(title)s_custom_audio.%(ext)s");
+
+		await page.click("#resetAudioFilenameTemplate");
+		savedAudioTpl = await page.evaluate(() => localStorage.getItem("filenameTemplateAudio"));
+		expect(savedAudioTpl).toBe("%(title)s.%(ext)s");
+		const audioVal = await page.inputValue("#filenameTemplateAudio");
+		expect(audioVal).toBe("%(title)s.%(ext)s");
+
+		// Video filename template
+		await page.fill("#filenameTemplateVideo", "%(title)s_custom_video.%(ext)s");
+		let savedVideoTpl = await page.evaluate(() => localStorage.getItem("filenameTemplateVideo"));
+		expect(savedVideoTpl).toBe("%(title)s_custom_video.%(ext)s");
+
+		await page.click("#resetFilenameTemplateVideo");
+		savedVideoTpl = await page.evaluate(() => localStorage.getItem("filenameTemplateVideo"));
+		expect(savedVideoTpl).toBe("%(title)s.%(ext)s");
+
+		// Playlist filename format
+		await page.fill("#filenameFormat", "%(playlist_index)s_%(title)s.%(ext)s");
+		let savedFileFmt = await page.evaluate(() => localStorage.getItem("filenameFormat"));
+		expect(savedFileFmt).toBe("%(playlist_index)s_%(title)s.%(ext)s");
+
+		await page.click("#resetFilenameFormat");
+		savedFileFmt = await page.evaluate(() => localStorage.getItem("filenameFormat"));
+		expect(savedFileFmt).toBe("%(playlist_index)s.%(title)s.%(ext)s");
+
+		// Playlist foldername format
+		await page.fill("#foldernameFormat", "%(playlist_title)s_folder");
+		let savedFolderFmt = await page.evaluate(() => localStorage.getItem("foldernameFormat"));
+		expect(savedFolderFmt).toBe("%(playlist_title)s_folder");
+
+		await page.click("#resetFoldernameFormat");
+		savedFolderFmt = await page.evaluate(() => localStorage.getItem("foldernameFormat"));
+		expect(savedFolderFmt).toBe("%(playlist_title)s");
+	});
+
+	test("cookie source selection toggles UI sections and saves preference", async () => {
+		await page.click('button[data-tab="advanced"]');
+
+		// Select browser cookies
+		await page.selectOption("#cookieSource", "browser");
+		await expect(page.locator("#browserSelectBox")).toBeVisible();
+		await expect(page.locator("#netscapeCookiesBox")).toBeHidden();
+		let savedSource = await page.evaluate(() => localStorage.getItem("cookieSource"));
+		expect(savedSource).toBe("browser");
+
+		// Select browser name
+		await page.selectOption("#browser", "firefox");
+		let savedBrowser = await page.evaluate(() => localStorage.getItem("browser"));
+		expect(savedBrowser).toBe("firefox");
+
+		// Select file cookies
+		await page.selectOption("#cookieSource", "file");
+		await expect(page.locator("#browserSelectBox")).toBeHidden();
+		await expect(page.locator("#netscapeCookiesBox")).toBeVisible();
+		savedSource = await page.evaluate(() => localStorage.getItem("cookieSource"));
+		expect(savedSource).toBe("file");
+	});
+
+	test("proxy and custom yt-dlp arguments update localStorage", async () => {
+		await page.click('button[data-tab="advanced"]');
+
+		const proxyUrl = "http://127.0.0.1:8080";
+		await page.fill("#proxyTxt", proxyUrl);
+		// Dispatch change event for input
+		await page.dispatchEvent("#proxyTxt", "change");
+		const savedProxy = await page.evaluate(() => localStorage.getItem("proxy"));
+		expect(savedProxy).toBe(proxyUrl);
+
+		const customArgs = "--sponsorblock-remove all";
+		await page.fill("#customArgsInput", customArgs);
+		const savedArgs = await page.evaluate(() => localStorage.getItem("customYtDlpArgs"));
+		expect(savedArgs).toBe(customArgs);
+	});
+});


### PR DESCRIPTION
----
## Summary by Gitar

- **Testing:**
    - Added comprehensive Playwright integration and UI test suite with `@playwright/test`
    - Added test helpers and mock setup for Electron, `yt-dlp`, and `ffmpeg` in `tests/helpers/electronApp.js`
    - Added test specs for compressor, main page downloads, playlist downloads, and preferences pages

<sub>This will update automatically on new commits.</sub>