### PR TITLE
Animation changes for download item and hidden menu

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1199,6 +1199,66 @@ h2 {
 	animation-fill-mode: forwards;
 }
 
+.fade-in {
+	animation: fadeInPanel 0.25s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+.fade-out {
+	animation: fadeOutPanel 0.15s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+@keyframes fadeInPanel {
+	0% {
+		opacity: 0;
+		transform: translateY(-8px);
+	}
+	100% {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@keyframes fadeOutPanel {
+	0% {
+		opacity: 1;
+		transform: translateY(0);
+	}
+	100% {
+		opacity: 0;
+		transform: translateY(-6px);
+	}
+}
+
+.item-fade-in {
+	animation: itemFadeIn 0.25s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+.item-fade-out {
+	animation: itemFadeOut 0.15s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+@keyframes itemFadeIn {
+	0% {
+		opacity: 0;
+		transform: translateY(-10px);
+	}
+	100% {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@keyframes itemFadeOut {
+	0% {
+		opacity: 1;
+		transform: translateY(0);
+	}
+	100% {
+		opacity: 0;
+		transform: translateY(-8px);
+	}
+}
+
 body::-webkit-scrollbar {
 	width: 8px;
 }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1331,6 +1331,7 @@ class YtDownloaderApp {
 	 */
 	handleDownloadRequest(type) {
 		this._updateDownloadOptionsFromUI();
+		this._hideInfoPanel(true);
 
 		const downloadJob = {
 			type,
@@ -1357,7 +1358,6 @@ class YtDownloaderApp {
 		} else {
 			this._queueDownload(downloadJob);
 		}
-		this._hideInfoPanel();
 	}
 
 	/**
@@ -1543,7 +1543,7 @@ class YtDownloaderApp {
 		const randomId = "queue_" + Math.random().toString(36).substring(2, 12);
 		this.state.downloadQueue.push({...job, queueId: randomId});
 		const itemHTML = `
-            <div class="item" id="${randomId}">
+            <div class="item item-fade-in" id="${randomId}">
                 <div class="itemIconBox">
                     <img src="${
 						job.thumbnail || "../assets/images/thumb.png"
@@ -2165,7 +2165,8 @@ class YtDownloaderApp {
 
 		const hiddenPanel = $(CONSTANTS.DOM_IDS.HIDDEN_PANEL);
 		hiddenPanel.style.display = "inline-block";
-		hiddenPanel.classList.add("scaleUp");
+		hiddenPanel.classList.remove("scaleUp", "scale", "fade-out");
+		hiddenPanel.classList.add("fade-in");
 	}
 
 	/**
@@ -2173,7 +2174,7 @@ class YtDownloaderApp {
 	 */
 	_createDownloadUI(randomId, job) {
 		const itemHTML = `
-            <div class="item" id="${randomId}">
+            <div class="item item-fade-in" id="${randomId}">
                 <div class="itemIconBox">
                     <img src="${
 						job.thumbnail || "../assets/images/thumb.png"
@@ -2396,15 +2397,20 @@ class YtDownloaderApp {
 	/**
 	 * Hides the info panel with an animation.
 	 */
-	_hideInfoPanel() {
+	_hideInfoPanel(immediate = false) {
 		const panel = $(CONSTANTS.DOM_IDS.HIDDEN_PANEL);
-		if (panel.style.display !== "none") {
-			panel.classList.remove("scaleUp");
-			panel.classList.add("scale");
-			setTimeout(() => {
+		if (panel && panel.style.display !== "none") {
+			if (immediate) {
 				panel.style.display = "none";
-				panel.classList.remove("scale");
-			}, 400);
+				panel.classList.remove("fade-in", "fade-out", "scaleUp", "scale");
+			} else {
+				panel.classList.remove("fade-in");
+				panel.classList.add("fade-out");
+				setTimeout(() => {
+					panel.style.display = "none";
+					panel.classList.remove("fade-out", "scaleUp", "scale");
+				}, 150);
+			}
 		}
 	}
 
@@ -2454,8 +2460,9 @@ class YtDownloaderApp {
 	_fadeAndRemoveItem(id) {
 		const item = $(id);
 		if (item) {
-			item.classList.add("scale");
-			setTimeout(() => item.remove(), 500);
+			item.classList.remove("item-fade-in", "scale");
+			item.classList.add("item-fade-out");
+			setTimeout(() => item.remove(), 160);
 		}
 	}
 

--- a/tests/main-page-downloads.spec.js
+++ b/tests/main-page-downloads.spec.js
@@ -191,4 +191,24 @@ test.describe("Main Page Download Tests", () => {
 		expect(extractCmd).toContain("-o");
 		expect(extractCmd.some((arg) => arg.includes("dQw4w9WgXcQ"))).toBe(true);
 	});
+
+	test("info panel hides immediately when download starts", async () => {
+		const testUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+		await page.evaluate((url) => {
+			window.electronAPI.clipboard.writeText(url);
+		}, testUrl);
+
+		await page.click("#pasteUrl");
+		await waitForInfoPanel(page);
+
+		await triggerClick(page, "videoDownload");
+
+		const isHiddenImmediately = await page.evaluate(() => {
+			const el = document.getElementById("hidden");
+			return el && el.style.display === "none";
+		});
+
+		expect(isHiddenImmediately).toBe(true);
+	});
 });


### PR DESCRIPTION
----
## Summary by Gitar

- **Animations & UI:**
    - Added new CSS keyframes and classes for smooth `fade-in` and `fade-out` panel animations
    - Added item fade-in and fade-out animations for newly created download items
- **Refactoring & Tests:**
    - Updated `_hideInfoPanel` to support immediate hiding when download requests start and added test coverage

<sub>This will update automatically on new commits.</sub>