### PR TITLE
Add option to select output container

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1239,6 +1239,7 @@ button {
 	border-radius: 16px;
 	padding: 20px 22px;
 	box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+	text-align: left;
 }
 
 .home-advanced-card {
@@ -1249,6 +1250,7 @@ button {
 	display: flex;
 	flex-direction: column;
 	gap: 12px;
+	text-align: left;
 }
 
 .home-advanced-header {
@@ -1258,6 +1260,7 @@ button {
 	color: var(--text);
 	font-size: 15px;
 	padding: 2px 0;
+	text-align: left;
 }
 
 .home-advanced-icon {
@@ -1316,6 +1319,28 @@ button {
 	border: 1px solid var(--box-separation);
 	background-color: var(--background);
 	border-radius: 8px;
+}
+
+#homeOutputFormatSelect {
+	width: 100%;
+	max-width: 100%;
+	margin: 0;
+	padding: 10px 14px;
+	background-color: var(--background);
+	color: var(--text);
+	border: 1px solid var(--box-separation);
+	border-radius: 8px;
+	outline: none;
+	font-family: inherit;
+	font-size: 14px;
+	box-sizing: border-box;
+	cursor: pointer;
+	transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+#homeOutputFormatSelect:focus {
+	border-color: var(--blueBtn);
+	box-shadow: 0 0 0 3px color-mix(in srgb, var(--blueBtn) 22%, transparent);
 }
 
 .advancedItem {

--- a/html/index.html
+++ b/html/index.html
@@ -398,6 +398,25 @@
                                 </label>
                             </div>
 
+                            <!-- Output Format Selection (Video only) -->
+                            <div class="home-advanced-card" id="homeOutputFormatCard">
+                                <div class="home-advanced-header">
+                                    <svg class="home-advanced-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                        <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>
+                                        <polyline points="3.27 6.96 12 12.01 20.73 6.96"/>
+                                        <line x1="12" y1="22.08" x2="12" y2="12"/>
+                                    </svg>
+                                    <span class="home-toggle-title" data-translate="outputFormat">Output Format</span>
+                                </div>
+                                <select id="homeOutputFormatSelect">
+                                    <option value="auto" data-translate="auto" selected>Auto (Default)</option>
+                                    <option value="mp4">MP4 (.mp4)</option>
+                                    <option value="mkv">MKV (.mkv)</option>
+                                    <option value="webm">WebM (.webm)</option>
+                                    <option value="mov">MOV (.mov)</option>
+                                </select>
+                            </div>
+
                             <!-- Custom yt-dlp arguments -->
                             <div class="home-advanced-card">
                                 <div class="home-advanced-header">

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ export function selectVideo(){
 	getId("audioList").style.display = "none";
 	getId("audioExtract").style.display = "none";
 	getId("videoList").style.display = "block";
+	const outputCard = getId("homeOutputFormatCard");
+	if (outputCard) outputCard.style.display = "flex";
 }
 window.selectVideo = selectVideo;
 
@@ -34,5 +36,7 @@ export function selectAudio(){
 	getId("videoList").style.display = "none";
 	getId("audioList").style.display = "block";
 	getId("audioExtract").style.display = "block";
+	const outputCard = getId("homeOutputFormatCard");
+	if (outputCard) outputCard.style.display = "none";
 }
 window.selectAudio = selectAudio;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -68,6 +68,7 @@ const CONSTANTS = {
 		EXTRACT_QUALITY_SELECT: "extractQualitySelect",
 		// Advanced Options
 		CUSTOM_ARGS_INPUT: "customArgsInput", // Add this line
+		HOME_OUTPUT_FORMAT_SELECT: "homeOutputFormatSelect",
 		START_TIME: "min-time",
 		END_TIME: "max-time",
 		MIN_SLIDER: "min-slider",
@@ -1483,6 +1484,9 @@ class YtDownloaderApp {
 				extractFormat: extractFormatVal,
 				extractQuality:
 					$(CONSTANTS.DOM_IDS.EXTRACT_QUALITY_SELECT)?.value || "0",
+				outputFormat:
+					$(CONSTANTS.DOM_IDS.HOME_OUTPUT_FORMAT_SELECT)?.value ||
+					"auto",
 			},
 		};
 
@@ -1804,6 +1808,7 @@ class YtDownloaderApp {
 						`bestvideo[height<=${presetQuality}]+bestaudio[ext=m4a]/best[height<=${presetQuality}]/best`,
 						"--merge-output-format",
 						"mp4",
+						// TODO: Consider doing a smart selection between remux/recode in future
 						"--recode-video",
 						"mp4",
 					];
@@ -1955,13 +1960,24 @@ class YtDownloaderApp {
 			}
 		}
 
+		if (type === "video") {
+			const targetFormat = uiSnapshot?.outputFormat;
+			if (targetFormat && targetFormat !== "auto") {
+				ext = targetFormat;
+				downloadArgs.push("--recode-video", targetFormat);
+				downloadArgs.push("--merge-output-format", targetFormat);
+			}
+		}
+
 		if (subs) downloadArgs.push(...subs.split(/\s+/));
 		if (subLangs) downloadArgs.push(...subLangs.split(/\s+/));
 		if (rangeOption) downloadArgs.push(rangeOption, rangeCmd);
 
-		const customArgsString = $(
-			CONSTANTS.DOM_IDS.CUSTOM_ARGS_INPUT,
-		).value.trim();
+		const homeCustomArgs = ($("customArgsInputHome")?.value || "").trim();
+		const prefCustomArgs = (
+			$(CONSTANTS.DOM_IDS.CUSTOM_ARGS_INPUT)?.value || ""
+		).trim();
+		const customArgsString = homeCustomArgs || prefCustomArgs;
 		if (customArgsString) {
 			const customArgs = customArgsString.split(/\s+/);
 			downloadArgs.push(...customArgs);

--- a/tests/main-page-downloads.spec.js
+++ b/tests/main-page-downloads.spec.js
@@ -211,4 +211,70 @@ test.describe("Main Page Download Tests", () => {
 
 		expect(isHiddenImmediately).toBe(true);
 	});
+
+	test("video download with output format selected remuxes into chosen container", async () => {
+		const testUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+		await page.evaluate((url) => {
+			window.electronAPI.clipboard.writeText(url);
+		}, testUrl);
+
+		await page.click("#pasteUrl");
+		await waitForInfoPanel(page);
+
+		// Open "More options"
+		await triggerClick(page, "advancedVideoToggle");
+
+		// Select mp4 output format
+		await page.selectOption("#homeOutputFormatSelect", "mp4");
+
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "videoDownload");
+
+		await page.waitForFunction(() => {
+			const cmds = window.__executedCommands || [];
+			return cmds.some((cmd) => cmd.includes("-f"));
+		});
+
+		const commands = await getExecutedCommands(page);
+		const downloadCmd = commands.find((cmd) => cmd.includes("-f"));
+		expect(downloadCmd).toBeDefined();
+		expect(downloadCmd).toContain("--recode-video");
+		expect(downloadCmd).toContain("mp4");
+		expect(downloadCmd).toContain("--merge-output-format");
+	});
+
+	test("video download with mkv output format passes mkv container args", async () => {
+		const testUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+		await page.evaluate((url) => {
+			window.electronAPI.clipboard.writeText(url);
+		}, testUrl);
+
+		await page.click("#pasteUrl");
+		await waitForInfoPanel(page);
+
+		// Open "More options"
+		await triggerClick(page, "advancedVideoToggle");
+
+		// Select mkv output format
+		await page.selectOption("#homeOutputFormatSelect", "mkv");
+
+		await clearExecutedCommands(page);
+
+		await triggerClick(page, "videoDownload");
+
+		await page.waitForFunction(() => {
+			const cmds = window.__executedCommands || [];
+			return cmds.some((cmd) => cmd.includes("-f"));
+		});
+
+		const commands = await getExecutedCommands(page);
+		const downloadCmd = commands.find((cmd) => cmd.includes("-f"));
+		expect(downloadCmd).toBeDefined();
+		expect(downloadCmd).toContain("--recode-video");
+		expect(downloadCmd).toContain("mkv");
+		expect(downloadCmd).toContain("--merge-output-format");
+	});
 });

--- a/translations/en.json
+++ b/translations/en.json
@@ -236,5 +236,7 @@
 	"clearQueue": "Clear Queue",
 	"downloadAll": "Download All",
 	"noVideosInQueue": "No videos in queue",
-	"stop": "Stop"
+	"stop": "Stop",
+	"outputFormat": "Output Format",
+	"outputFormatDesc": "Set the desired output container (e.g. MP4, MKV, WebM)"
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **New Features:**
    - Added output container selection dropdown in advanced video options (`homeOutputFormatSelect`)
    - Configured yt-dlp arguments `--recode-video` and `--merge-output-format` based on selected container
    - Added English translations for output format options and UI elements
- **Tests:**
    - Added end-to-end tests verifying correct container arguments for `mp4` and `mkv` selections

<sub>This will update automatically on new commits.</sub>