### PR TITLE
Optimize binary resolution by only copying FFmpeg and Node for MS Store builds

### DIFF
--- a/src/compressor.js
+++ b/src/compressor.js
@@ -11,6 +11,7 @@ const {
 	crypto,
 	env,
 	__dirname,
+	windowsStore,
 } = window.electronAPI;
 
 document.addEventListener("translations-loaded", () => {
@@ -954,31 +955,33 @@ function getFfmpegPath() {
 		return env.YTDOWNLOADER_FFMPEG_PATH;
 	}
 
-	switch (os.platform()) {
-		case "win32":
-			return path.join(
-				os.homedir(),
-				".ytDownloader",
-				"ffmpeg",
-				"bin",
-				"ffmpeg.exe",
-			);
-		case "freebsd":
-			try {
-				return execSync("which ffmpeg").toString("utf8").trim();
-			} catch (error) {
-				console.error("ffmpeg not found on FreeBSD:", error);
-				return "";
-			}
-		default:
-			return path.join(
-				os.homedir(),
-				".ytDownloader",
-				"ffmpeg",
-				"bin",
-				"ffmpeg",
-			);
+	if (os.platform() === "freebsd") {
+		try {
+			return execSync("which ffmpeg").toString("utf8").trim();
+		} catch (error) {
+			console.error("ffmpeg not found on FreeBSD:", error);
+			return "";
+		}
 	}
+
+	const isWin = os.platform() === "win32";
+	const ffmpegName = isWin ? "ffmpeg.exe" : "ffmpeg";
+	const bundledFfmpegFile = path.join(__dirname, "..", "ffmpeg", "bin", ffmpegName);
+	const storeFfmpegFile = path.join(os.homedir(), ".ytDownloader", "ffmpeg", "bin", ffmpegName);
+
+	if (windowsStore) {
+		return storeFfmpegFile;
+	}
+
+	if (existsSync(bundledFfmpegFile)) {
+		return bundledFfmpegFile;
+	}
+
+	if (existsSync(storeFfmpegFile)) {
+		return storeFfmpegFile;
+	}
+
+	return bundledFfmpegFile;
 }
 
 dom.outputFolderInput.addEventListener("change", (e) => {

--- a/src/compressor.js
+++ b/src/compressor.js
@@ -2,7 +2,6 @@ import { getId, formatBytes } from "./utils.js";
 
 const {
 	spawn,
-	execSync,
 	path,
 	ipcRenderer,
 	os,
@@ -11,7 +10,6 @@ const {
 	crypto,
 	env,
 	__dirname,
-	windowsStore,
 } = window.electronAPI;
 
 document.addEventListener("translations-loaded", () => {
@@ -88,9 +86,6 @@ dom.menuIcon.addEventListener("click", () => {
 		openMenu();
 	}
 });
-
-const ffmpeg = getFfmpegPath();
-console.log(ffmpeg);
 
 const vaapi_device = "/dev/dri/renderD128";
 
@@ -295,7 +290,8 @@ async function compressVideo(file, settings, itemId, outputPath) {
 		const isTestMode = Boolean(window.electronAPI && window.electronAPI.isTest);
 		const mockSpawn = isTestMode ? (window.__mockSpawn || window.__mockFfmpeg) : null;
 		const spawnFn = mockSpawn || spawn;
-		const child = spawnFn(ffmpeg, args);
+		const ffmpegPath = getFfmpegPath();
+		const child = spawnFn(ffmpegPath, args);
 
 		activeProcesses.add(child);
 		child.on("exit", () => {
@@ -945,46 +941,20 @@ function timeToSeconds(timeStr) {
 }
 
 function getFfmpegPath() {
-	if (window.electronAPI && window.electronAPI.isTest && (window.__mockYtDlp || window.__mockSpawn || window.__mockFfmpeg)) return "ffmpeg";
+	const isTestMode = Boolean(window.electronAPI && window.electronAPI.isTest);
+	if (isTestMode && (window.__mockYtDlp || window.__mockSpawn || window.__mockFfmpeg)) return "ffmpeg";
 	if (
 		env &&
 		env.YTDOWNLOADER_FFMPEG_PATH &&
 		existsSync(env.YTDOWNLOADER_FFMPEG_PATH)
 	) {
-		console.log("Using FFMPEG from YTDOWNLOADER_FFMPEG_PATH");
 		return env.YTDOWNLOADER_FFMPEG_PATH;
 	}
 
-	if (os.platform() === "freebsd") {
-		try {
-			return execSync("which ffmpeg").toString("utf8").trim();
-		} catch (error) {
-			console.error("ffmpeg not found on FreeBSD:", error);
-			return "";
-		}
-	}
-
-	const isWin = os.platform() === "win32";
-	const ffmpegName = isWin ? "ffmpeg.exe" : "ffmpeg";
-	const bundledFfmpegFile = path.join(__dirname, "..", "ffmpeg", "bin", ffmpegName);
-	const storeFfmpegFile = path.join(os.homedir(), ".ytDownloader", "ffmpeg", "bin", ffmpegName);
-
-	if (windowsStore) {
-		if (existsSync(storeFfmpegFile)) {
-			return storeFfmpegFile;
-		}
-		return "";
-	}
-
-	if (existsSync(bundledFfmpegFile)) {
-		return bundledFfmpegFile;
-	}
-
-	if (existsSync(storeFfmpegFile)) {
-		return storeFfmpegFile;
-	}
-
-	return "";
+	const dir = window.AppBinaries?.ffmpegPath;
+	if (!dir) return "";
+	const ext = os.platform() === "win32" ? ".exe" : "";
+	return path.join(dir, "ffmpeg" + ext);
 }
 
 dom.outputFolderInput.addEventListener("change", (e) => {
@@ -1034,9 +1004,19 @@ Object.entries(menuRoutes).forEach(([domKey, route]) => {
 
 // Target Size / CRF Mode helper functions
 function getFfprobePath() {
-	const ffmpegPath = getFfmpegPath();
-	if (!ffmpegPath) return "";
-	const dir = path.dirname(ffmpegPath);
+	const isTestMode = Boolean(window.electronAPI && window.electronAPI.isTest);
+	if (isTestMode && (window.__mockYtDlp || window.__mockSpawn || window.__mockFfmpeg)) return "ffprobe";
+	if (
+		env &&
+		env.YTDOWNLOADER_FFMPEG_PATH &&
+		existsSync(env.YTDOWNLOADER_FFMPEG_PATH)
+	) {
+		const dir = path.dirname(env.YTDOWNLOADER_FFMPEG_PATH);
+		const ext = os.platform() === "win32" ? ".exe" : "";
+		return path.join(dir, "ffprobe" + ext);
+	}
+	const dir = window.AppBinaries?.ffmpegPath;
+	if (!dir) return "";
 	const ext = os.platform() === "win32" ? ".exe" : "";
 	return path.join(dir, "ffprobe" + ext);
 }

--- a/src/compressor.js
+++ b/src/compressor.js
@@ -1,4 +1,4 @@
-import { getId, formatBytes } from "./utils.js";
+import { getId, formatBytes, getFfmpegPath, getFfprobePath } from "./utils.js";
 
 const {
 	spawn,
@@ -940,22 +940,7 @@ function timeToSeconds(timeStr) {
 	return hh * 3600 + mm * 60 + ss;
 }
 
-function getFfmpegPath() {
-	const isTestMode = Boolean(window.electronAPI && window.electronAPI.isTest);
-	if (isTestMode && (window.__mockYtDlp || window.__mockSpawn || window.__mockFfmpeg)) return "ffmpeg";
-	if (
-		env &&
-		env.YTDOWNLOADER_FFMPEG_PATH &&
-		existsSync(env.YTDOWNLOADER_FFMPEG_PATH)
-	) {
-		return env.YTDOWNLOADER_FFMPEG_PATH;
-	}
 
-	const dir = window.AppBinaries?.ffmpegPath;
-	if (!dir) return "";
-	const ext = os.platform() === "win32" ? ".exe" : "";
-	return path.join(dir, "ffmpeg" + ext);
-}
 
 dom.outputFolderInput.addEventListener("change", (e) => {
 	const checked = e.target.checked;
@@ -1003,23 +988,6 @@ Object.entries(menuRoutes).forEach(([domKey, route]) => {
 });
 
 // Target Size / CRF Mode helper functions
-function getFfprobePath() {
-	const isTestMode = Boolean(window.electronAPI && window.electronAPI.isTest);
-	if (isTestMode && (window.__mockYtDlp || window.__mockSpawn || window.__mockFfmpeg)) return "ffprobe";
-	if (
-		env &&
-		env.YTDOWNLOADER_FFMPEG_PATH &&
-		existsSync(env.YTDOWNLOADER_FFMPEG_PATH)
-	) {
-		const dir = path.dirname(env.YTDOWNLOADER_FFMPEG_PATH);
-		const ext = os.platform() === "win32" ? ".exe" : "";
-		return path.join(dir, "ffprobe" + ext);
-	}
-	const dir = window.AppBinaries?.ffmpegPath;
-	if (!dir) return "";
-	const ext = os.platform() === "win32" ? ".exe" : "";
-	return path.join(dir, "ffprobe" + ext);
-}
 
 function getVideoDuration(filePath) {
 	const ffprobe = getFfprobePath();

--- a/src/compressor.js
+++ b/src/compressor.js
@@ -970,7 +970,10 @@ function getFfmpegPath() {
 	const storeFfmpegFile = path.join(os.homedir(), ".ytDownloader", "ffmpeg", "bin", ffmpegName);
 
 	if (windowsStore) {
-		return storeFfmpegFile;
+		if (existsSync(storeFfmpegFile)) {
+			return storeFfmpegFile;
+		}
+		return "";
 	}
 
 	if (existsSync(bundledFfmpegFile)) {
@@ -981,7 +984,7 @@ function getFfmpegPath() {
 		return storeFfmpegFile;
 	}
 
-	return bundledFfmpegFile;
+	return "";
 }
 
 dom.outputFolderInput.addEventListener("change", (e) => {

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -975,7 +975,10 @@ const playlistDownloader = {
 		const storeBinDir = path.join(os.homedir(), ".ytDownloader", "ffmpeg", "bin");
 
 		if (windowsStore) {
-			return storeBinDir;
+			if (fs.existsSync(path.join(storeBinDir, ffmpegName))) {
+				return storeBinDir;
+			}
+			return "";
 		}
 
 		if (fs.existsSync(path.join(bundledBinDir, ffmpegName))) {
@@ -986,7 +989,7 @@ const playlistDownloader = {
 			return storeBinDir;
 		}
 
-		return bundledBinDir;
+		return "";
 	},
 
 	getJsRuntimePath() {

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -7,11 +7,9 @@ const {
 	path,
 	os,
 	fs,
-	execSync,
 	constants,
 	env,
 	__dirname,
-	windowsStore,
 } = window.electronAPI;
 
 const playlistDownloader = {
@@ -186,16 +184,21 @@ const playlistDownloader = {
 		const isTestMode = Boolean(window.electronAPI && window.electronAPI.isTest);
 		const mockYtDlp = isTestMode ? window.__mockYtDlp : null;
 
-		if (window.AppBinaries && !mockYtDlp) {
+		if (mockYtDlp) {
+			this.state.ytDlpPath = "mock-ytdlp";
+			this.state.ytDlpWrap = mockYtDlp;
+			this.state.ffmpegPath = "ffmpeg";
+			this.state.jsRuntimePath = "";
+		} else if (window.AppBinaries) {
 			this.state.ytDlpPath = window.AppBinaries.ytDlpPath;
 			this.state.ytDlpWrap = window.AppBinaries.ytDlp;
 			this.state.ffmpegPath = window.AppBinaries.ffmpegPath;
 			this.state.jsRuntimePath = window.AppBinaries.jsRuntimePath;
 		} else {
-			this.state.ytDlpPath = mockYtDlp ? "mock-ytdlp" : localStorage.getItem("ytdlp");
-			this.state.ytDlpWrap = mockYtDlp || YTDlpWrap.new(this.state.ytDlpPath);
-			this.state.ffmpegPath = mockYtDlp ? "ffmpeg" : this.getFfmpegPath();
-			this.state.jsRuntimePath = mockYtDlp ? "" : this.getJsRuntimePath();
+			this.state.ytDlpPath = localStorage.getItem("ytdlp") || "";
+			this.state.ytDlpWrap = this.state.ytDlpPath ? YTDlpWrap.new(this.state.ytDlpPath) : null;
+			this.state.ffmpegPath = "";
+			this.state.jsRuntimePath = "";
 		}
 
 		const defaultDownloadsDir = path.join(os.homedir(), "Downloads");
@@ -948,96 +951,6 @@ const playlistDownloader = {
 		ipcRenderer.send(event, path.join(__dirname, page));
 	},
 
-	getFfmpegPath() {
-		if (window.electronAPI && window.electronAPI.isTest && window.__mockYtDlp) return "ffmpeg";
-		if (
-			env &&
-			env.YTDOWNLOADER_FFMPEG_PATH &&
-			fs.existsSync(env.YTDOWNLOADER_FFMPEG_PATH)
-		) {
-			console.log("Using FFMPEG from YTDOWNLOADER_FFMPEG_PATH");
-
-			return env.YTDOWNLOADER_FFMPEG_PATH;
-		}
-
-		if (os.platform() === "freebsd") {
-			try {
-				return execSync("which ffmpeg").toString("utf8").trim();
-			} catch (error) {
-				console.error("ffmpeg not found on FreeBSD:", error);
-				return "";
-			}
-		}
-
-		const isWin = os.platform() === "win32";
-		const ffmpegName = isWin ? "ffmpeg.exe" : "ffmpeg";
-		const bundledBinDir = path.join(__dirname, "..", "ffmpeg", "bin");
-		const storeBinDir = path.join(os.homedir(), ".ytDownloader", "ffmpeg", "bin");
-
-		if (windowsStore) {
-			if (fs.existsSync(path.join(storeBinDir, ffmpegName))) {
-				return storeBinDir;
-			}
-			return "";
-		}
-
-		if (fs.existsSync(path.join(bundledBinDir, ffmpegName))) {
-			return bundledBinDir;
-		}
-
-		if (fs.existsSync(path.join(storeBinDir, ffmpegName))) {
-			return storeBinDir;
-		}
-
-		return "";
-	},
-
-	getJsRuntimePath() {
-		if (window.electronAPI && window.electronAPI.isTest && window.__mockYtDlp) return "";
-
-		const exeName = "node";
-
-		if (env && env.YTDOWNLOADER_NODE_PATH) {
-			if (fs.existsSync(env.YTDOWNLOADER_NODE_PATH)) {
-				return `$node:${env.YTDOWNLOADER_NODE_PATH}`;
-			}
-
-			return "";
-		}
-
-		if (env && env.YTDOWNLOADER_DENO_PATH) {
-			if (fs.existsSync(env.YTDOWNLOADER_DENO_PATH)) {
-				return `$deno:${env.YTDOWNLOADER_DENO_PATH}`;
-			}
-
-			return "";
-		}
-
-		if (os.platform() === "darwin") {
-			return "";
-		}
-
-		const nodeName = os.platform() === "win32" ? `${exeName}.exe` : exeName;
-		const bundledNode = path.join(__dirname, "..", nodeName);
-		const storeNode = path.join(os.homedir(), ".ytDownloader", nodeName);
-
-		if (windowsStore) {
-			if (fs.existsSync(storeNode)) {
-				return `${exeName}:${storeNode}`;
-			}
-			return "";
-		}
-
-		if (fs.existsSync(bundledNode)) {
-			return `${exeName}:${bundledNode}`;
-		}
-
-		if (fs.existsSync(storeNode)) {
-			return `${exeName}:${storeNode}`;
-		}
-
-		return "";
-	},
 	validateUrl(rawUrl) {
 		const input = String(rawUrl ?? "").trim();
 

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -11,6 +11,7 @@ const {
 	constants,
 	env,
 	__dirname,
+	windowsStore,
 } = window.electronAPI;
 
 const playlistDownloader = {
@@ -959,76 +960,80 @@ const playlistDownloader = {
 			return env.YTDOWNLOADER_FFMPEG_PATH;
 		}
 
-		switch (os.platform()) {
-			case "win32":
-				return path.join(
-					os.homedir(),
-					".ytDownloader",
-					"ffmpeg",
-					"bin",
-				);
-			case "freebsd":
-				try {
-					return execSync("which ffmpeg").toString("utf8").trim();
-				} catch (error) {
-					console.error("ffmpeg not found on FreeBSD:", error);
-					return "";
-				}
-			default:
-				return path.join(
-					os.homedir(),
-					".ytDownloader",
-					"ffmpeg",
-					"bin",
-				);
+		if (os.platform() === "freebsd") {
+			try {
+				return execSync("which ffmpeg").toString("utf8").trim();
+			} catch (error) {
+				console.error("ffmpeg not found on FreeBSD:", error);
+				return "";
+			}
 		}
+
+		const isWin = os.platform() === "win32";
+		const ffmpegName = isWin ? "ffmpeg.exe" : "ffmpeg";
+		const bundledBinDir = path.join(__dirname, "..", "ffmpeg", "bin");
+		const storeBinDir = path.join(os.homedir(), ".ytDownloader", "ffmpeg", "bin");
+
+		if (windowsStore) {
+			return storeBinDir;
+		}
+
+		if (fs.existsSync(path.join(bundledBinDir, ffmpegName))) {
+			return bundledBinDir;
+		}
+
+		if (fs.existsSync(path.join(storeBinDir, ffmpegName))) {
+			return storeBinDir;
+		}
+
+		return bundledBinDir;
 	},
 
 	getJsRuntimePath() {
 		if (window.electronAPI && window.electronAPI.isTest && window.__mockYtDlp) return "";
-		{
-			const exeName = "node";
 
-			if (env && env.YTDOWNLOADER_NODE_PATH) {
-				if (fs.existsSync(env.YTDOWNLOADER_NODE_PATH)) {
-					return `$node:${env.YTDOWNLOADER_NODE_PATH}`;
-				}
+		const exeName = "node";
 
-				return "";
+		if (env && env.YTDOWNLOADER_NODE_PATH) {
+			if (fs.existsSync(env.YTDOWNLOADER_NODE_PATH)) {
+				return `$node:${env.YTDOWNLOADER_NODE_PATH}`;
 			}
 
-			if (env && env.YTDOWNLOADER_DENO_PATH) {
-				if (fs.existsSync(env.YTDOWNLOADER_DENO_PATH)) {
-					return `$deno:${env.YTDOWNLOADER_DENO_PATH}`;
-				}
-
-				return "";
-			}
-
-			if (os.platform() === "darwin") {
-				return "";
-			}
-
-			let jsRuntimePath = path.join(
-				os.homedir(),
-				".ytDownloader",
-				exeName,
-			);
-
-			if (os.platform() === "win32") {
-				jsRuntimePath = path.join(
-					os.homedir(),
-					".ytDownloader",
-					`${exeName}.exe`,
-				);
-			}
-
-			if (fs.existsSync(jsRuntimePath)) {
-				return `${exeName}:${jsRuntimePath}`;
-			} else {
-				return "";
-			}
+			return "";
 		}
+
+		if (env && env.YTDOWNLOADER_DENO_PATH) {
+			if (fs.existsSync(env.YTDOWNLOADER_DENO_PATH)) {
+				return `$deno:${env.YTDOWNLOADER_DENO_PATH}`;
+			}
+
+			return "";
+		}
+
+		if (os.platform() === "darwin") {
+			return "";
+		}
+
+		const nodeName = os.platform() === "win32" ? `${exeName}.exe` : exeName;
+		const bundledNode = path.join(__dirname, "..", nodeName);
+		const storeNode = path.join(os.homedir(), ".ytDownloader", nodeName);
+
+		if (windowsStore) {
+			if (fs.existsSync(storeNode)) {
+				return `${exeName}:${storeNode}`;
+			}
+			return "";
+		}
+
+		if (fs.existsSync(bundledNode)) {
+			return `${exeName}:${bundledNode}`;
+		}
+
+		if (fs.existsSync(storeNode)) {
+			return `${exeName}:${storeNode}`;
+		}
+
+		return "";
 	},
 	validateUrl(rawUrl) {
 		const input = String(rawUrl ?? "").trim();

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -11,6 +11,8 @@ const {
 	platform,
 	exec,
 	env,
+	__dirname,
+	windowsStore,
 } = window.electronAPI;
 
 function initPreferencesUI() {
@@ -826,8 +828,15 @@ function initDependenciesTab() {
 			});
 		} else {
 			let bundledFfmpegBin = "";
-			if (homedir) {
-				const exeName = platform && platform() === "win32" ? "ffmpeg.exe" : "ffmpeg";
+			const exeName = platform && platform() === "win32" ? "ffmpeg.exe" : "ffmpeg";
+			if (windowsStore && homedir) {
+				bundledFfmpegBin = join(homedir(), ".ytDownloader", "ffmpeg", "bin", exeName);
+			} else if (__dirname) {
+				bundledFfmpegBin = join(__dirname, "..", "ffmpeg", "bin", exeName);
+				if (!fs.existsSync(bundledFfmpegBin) && homedir) {
+					bundledFfmpegBin = join(homedir(), ".ytDownloader", "ffmpeg", "bin", exeName);
+				}
+			} else if (homedir) {
 				bundledFfmpegBin = join(homedir(), ".ytDownloader", "ffmpeg", "bin", exeName);
 			}
 			if (bundledFfmpegBin && fs && fs.existsSync && fs.existsSync(bundledFfmpegBin)) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -431,7 +431,6 @@ class YtDownloaderApp {
 		const defaultYtDlpName = platform() === "win32" ? "ytdlp.exe" : "ytdlp";
 		const defaultYtDlpPath = join(hiddenDir, defaultYtDlpName);
 		const isMacOS = platform() === "darwin";
-		const isFreeBSD = platform() === "freebsd";
 
 		let executablePath = null;
 
@@ -464,18 +463,7 @@ class YtDownloaderApp {
 			}
 		}
 
-		// PRIORITY 3: FreeBSD
-		else if (isFreeBSD) {
-			try {
-				executablePath = execSync("which yt-dlp").toString().trim();
-			} catch {
-				throw new Error(
-					"No yt-dlp found in PATH on FreeBSD. Please install it.",
-				);
-			}
-		}
-
-		// PRIORITY 4: User-selected source (Windows/Linux)
+		// PRIORITY 3: User-selected source (Windows/Linux)
 		else {
 			const source =
 				localStorage.getItem(

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,4 +1,11 @@
-import {getId as $, showPopup, formatTime} from "./utils.js";
+import {
+	getId as $,
+	showPopup,
+	formatTime,
+	findFfmpeg,
+	ensureFfmpegLibsLoadable,
+	getJsRuntimePath,
+} from "./utils.js";
 import {selectVideo, selectAudio} from "./index.js";
 
 const {
@@ -199,11 +206,11 @@ class YtDownloaderApp {
 			this.state.ytDlp = mockYtDlp || YTDlpWrap.new(this.state.ytDlpPath);
 			this.state.ffmpegPath = mockYtDlp
 				? "ffmpeg"
-				: await this._findFfmpeg();
-			this._ensureFfmpegLibsLoadable(this.state.ffmpegPath);
+				: await findFfmpeg();
+			ensureFfmpegLibsLoadable(this.state.ffmpegPath);
 			this.state.jsRuntimePath = mockYtDlp
 				? ""
-				: await this._getJsRuntimePath();
+				: await getJsRuntimePath();
 
 			window.AppBinaries = {
 				ytDlpPath: this.state.ytDlpPath,
@@ -266,11 +273,11 @@ class YtDownloaderApp {
 				const ytDlp = mockYtDlp || YTDlpWrap.new(ytDlpPath);
 				const ffmpegPath = mockYtDlp
 					? "ffmpeg"
-					: await this._findFfmpeg();
-				this._ensureFfmpegLibsLoadable(ffmpegPath);
+					: await findFfmpeg();
+				ensureFfmpegLibsLoadable(ffmpegPath);
 				const jsRuntimePath = mockYtDlp
 					? ""
-					: await this._getJsRuntimePath();
+					: await getJsRuntimePath();
 
 				// Atomic update of state once all resolvers complete
 				this.state.ytDlpPath = ytDlpPath;
@@ -668,217 +675,6 @@ class YtDownloaderApp {
 				throw new Error("Failed to download yt-dlp.");
 			}
 		}
-	}
-
-	/**
-	 * Locates the ffmpeg executable path.
-	 * @returns {Promise<string>} A promise that resolves with the path to ffmpeg.
-	 */
-	async _findFfmpeg() {
-		// Priority 1: Environment Variable
-		if (env && env.YTDOWNLOADER_FFMPEG_PATH) {
-			if (existsSync(env.YTDOWNLOADER_FFMPEG_PATH)) {
-				return env.YTDOWNLOADER_FFMPEG_PATH;
-			}
-			throw new Error(
-				"YTDOWNLOADER_FFMPEG_PATH is set, but no file exists there.",
-			);
-		}
-
-		// Priority 2: System-installed (FreeBSD)
-		if (platform() === "freebsd") {
-			try {
-				return execSync("which ffmpeg").toString().trim();
-			} catch {
-				throw new Error(
-					"No ffmpeg found in PATH on FreeBSD. App may not work correctly.",
-				);
-			}
-		}
-
-		// Priority 2.5: User-selected system ffmpeg
-		const ffmpegSource = localStorage.getItem("ffmpegSource") || "bundled";
-		if (ffmpegSource === "system") {
-			try {
-				let sysPath;
-				if (platform() === "win32") {
-					sysPath = execSync("where ffmpeg")
-						.toString()
-						.split(/\r?\n/)[0]
-						.trim();
-				} else {
-					sysPath = execSync("command -v ffmpeg || which ffmpeg")
-						.toString()
-						.split(/\r?\n/)[0]
-						.trim();
-				}
-				if (sysPath && existsSync(sysPath)) {
-					return dirname(sysPath);
-				}
-			} catch {
-				console.warn(
-					"System ffmpeg not found in PATH; falling back to bundled.",
-				);
-			}
-		}
-
-		// Priority 3: Bundled ffmpeg
-		const bundledDir = join(__dirname, "..", "ffmpeg");
-		const isWin = platform() === "win32";
-		const ffmpegName = isWin ? "ffmpeg.exe" : "ffmpeg";
-		const bundledFfmpegFile = join(bundledDir, "bin", ffmpegName);
-
-		// MS Store packages run in a restricted WindowsApps container where executing binaries fails
-		if (windowsStore) {
-			const targetDir = join(homedir(), ".ytDownloader", "ffmpeg");
-			const targetFfmpegFile = join(targetDir, "bin", ffmpegName);
-
-			if (!existsSync(targetFfmpegFile)) {
-				if (existsSync(bundledDir)) {
-					try {
-						cpSync(bundledDir, targetDir, {
-							recursive: true,
-							dereference: true,
-						});
-					} catch {
-						console.error("Failed to copy bundled ffmpeg.");
-						return "";
-					}
-				} else {
-					return "";
-				}
-			}
-
-			return join(targetDir, "bin");
-		}
-
-		if (existsSync(bundledFfmpegFile)) {
-			return join(bundledDir, "bin");
-		}
-
-		// Fallback if existing copy is present in ~/.ytDownloader
-		const fallbackDir = join(homedir(), ".ytDownloader", "ffmpeg", "bin");
-		if (existsSync(join(fallbackDir, ffmpegName))) {
-			return fallbackDir;
-		}
-
-		return "";
-	}
-
-	/**
-	 * The bundled Linux ffmpeg is dynamically linked and ships its shared
-	 * libraries in a sibling "lib" directory, but its RPATH is broken, so it
-	 * cannot find them on its own. yt-dlp spawns ffmpeg as a child process, so
-	 * we expose that lib directory via LD_LIBRARY_PATH (inherited by children).
-	 * Without this, audio extraction fails with "ffprobe and ffmpeg not found".
-	 * @param {string} ffmpegPath Path to the bundled ffmpeg "bin" directory.
-	 */
-	_ensureFfmpegLibsLoadable(ffmpegPath) {
-		if (platform() !== "linux" || !ffmpegPath) {
-			return;
-		}
-
-		const libDir = join(ffmpegPath, "..", "lib");
-		if (!existsSync(libDir)) {
-			return;
-		}
-
-		const current = env ? env.LD_LIBRARY_PATH : undefined;
-		if (current) {
-			if (!current.split(":").includes(libDir)) {
-				setEnv("LD_LIBRARY_PATH", `${libDir}:${current}`);
-			}
-		} else {
-			setEnv("LD_LIBRARY_PATH", libDir);
-		}
-	}
-
-	/**
-	 * Determines the JavaScript runtime path for yt-dlp.
-	 * @returns {Promise<string>} A promise that resolves with the JS runtime path.
-	 */
-	async _getJsRuntimePath() {
-		const exeName = "node";
-
-		// Priority 1: Environment Variable (Node)
-		if (env && env.YTDOWNLOADER_NODE_PATH) {
-			if (existsSync(env.YTDOWNLOADER_NODE_PATH)) {
-				return `$node:${env.YTDOWNLOADER_NODE_PATH}`;
-			}
-
-			return "";
-		}
-
-		// Priority 2: Environment Variable (Deno)
-		if (env && env.YTDOWNLOADER_DENO_PATH) {
-			if (existsSync(env.YTDOWNLOADER_DENO_PATH)) {
-				return `$deno:${env.YTDOWNLOADER_DENO_PATH}`;
-			}
-
-			return "";
-		}
-
-		// Priority 3: System-installed Deno (macOS Fallback)
-		if (platform() === "darwin") {
-			const possiblePaths = [
-				"/opt/homebrew/bin/deno",
-				"/usr/local/bin/deno",
-			];
-
-			for (const p of possiblePaths) {
-				if (existsSync(p)) {
-					return `deno:${p}`;
-				}
-			}
-
-			console.log("No Deno installation found");
-
-			return "";
-		}
-
-		// Priority 4: Bundled Node Runtime
-		const isWin = platform() === "win32";
-		const nodeName = isWin ? "node.exe" : "node";
-
-		const bundledNodePath = join(__dirname, "..", nodeName);
-
-		// MS Store packages run in a restricted WindowsApps container
-		if (windowsStore) {
-			const targetDir = join(homedir(), ".ytDownloader");
-			const targetNodeFile = join(targetDir, nodeName);
-
-			if (existsSync(targetNodeFile)) {
-				return `${exeName}:${targetNodeFile}`;
-			}
-
-			if (existsSync(bundledNodePath)) {
-				if (!existsSync(targetDir)) {
-					mkdirSync(targetDir, {recursive: true});
-				}
-
-				try {
-					copyFileSync(bundledNodePath, targetNodeFile);
-				} catch {
-					console.error("Failed to copy bundled Node runtime.");
-					return "";
-				}
-
-				return `${exeName}:${targetNodeFile}`;
-			}
-
-			return "";
-		}
-
-		if (existsSync(bundledNodePath)) {
-			return `${exeName}:${bundledNodePath}`;
-		}
-
-		const fallbackNodePath = join(homedir(), ".ytDownloader", nodeName);
-		if (existsSync(fallbackNodePath)) {
-			return `${exeName}:${fallbackNodePath}`;
-		}
-
-		return "";
 	}
 
 	/**

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -724,31 +724,45 @@ class YtDownloaderApp {
 
 		// Priority 3: Bundled ffmpeg
 		const bundledDir = join(__dirname, "..", "ffmpeg");
-		const targetDir = join(homedir(), ".ytDownloader", "ffmpeg");
-
 		const isWin = platform() === "win32";
 		const ffmpegName = isWin ? "ffmpeg.exe" : "ffmpeg";
-		const targetFfmpegFile = join(targetDir, "bin", ffmpegName);
+		const bundledFfmpegFile = join(bundledDir, "bin", ffmpegName);
 
-		// Check if the folder has already been copied
-		if (!existsSync(targetFfmpegFile)) {
-			if (existsSync(bundledDir)) {
-				try {
-					cpSync(bundledDir, targetDir, {
-						recursive: true,
-						dereference: true,
-					});
-				} catch {
-					console.error("Failed to copy bundled ffmpeg.");
+		// MS Store packages run in a restricted WindowsApps container where executing binaries fails
+		if (windowsStore) {
+			const targetDir = join(homedir(), ".ytDownloader", "ffmpeg");
+			const targetFfmpegFile = join(targetDir, "bin", ffmpegName);
 
+			if (!existsSync(targetFfmpegFile)) {
+				if (existsSync(bundledDir)) {
+					try {
+						cpSync(bundledDir, targetDir, {
+							recursive: true,
+							dereference: true,
+						});
+					} catch {
+						console.error("Failed to copy bundled ffmpeg.");
+						return "";
+					}
+				} else {
 					return "";
 				}
-			} else {
-				return "";
 			}
+
+			return join(targetDir, "bin");
 		}
 
-		return join(targetDir, "bin");
+		if (existsSync(bundledFfmpegFile)) {
+			return join(bundledDir, "bin");
+		}
+
+		// Fallback if existing copy is present in ~/.ytDownloader
+		const fallbackDir = join(homedir(), ".ytDownloader", "ffmpeg", "bin");
+		if (existsSync(join(fallbackDir, ffmpegName))) {
+			return fallbackDir;
+		}
+
+		return "";
 	}
 
 	/**
@@ -827,29 +841,41 @@ class YtDownloaderApp {
 		const nodeName = isWin ? "node.exe" : "node";
 
 		const bundledNodePath = join(__dirname, "..", nodeName);
-		const targetDir = join(homedir(), ".ytDownloader");
-		const targetNodeFile = join(targetDir, nodeName);
 
-		// Check if folder has already been copied
-		if (existsSync(targetNodeFile)) {
-			return `${exeName}:${targetNodeFile}`;
+		// MS Store packages run in a restricted WindowsApps container
+		if (windowsStore) {
+			const targetDir = join(homedir(), ".ytDownloader");
+			const targetNodeFile = join(targetDir, nodeName);
+
+			if (existsSync(targetNodeFile)) {
+				return `${exeName}:${targetNodeFile}`;
+			}
+
+			if (existsSync(bundledNodePath)) {
+				if (!existsSync(targetDir)) {
+					mkdirSync(targetDir, {recursive: true});
+				}
+
+				try {
+					copyFileSync(bundledNodePath, targetNodeFile);
+				} catch {
+					console.error("Failed to copy bundled Node runtime.");
+					return "";
+				}
+
+				return `${exeName}:${targetNodeFile}`;
+			}
+
+			return "";
 		}
 
-		// Copy to .ytDownloader
 		if (existsSync(bundledNodePath)) {
-			if (!existsSync(targetDir)) {
-				mkdirSync(targetDir, {recursive: true});
-			}
+			return `${exeName}:${bundledNodePath}`;
+		}
 
-			try {
-				copyFileSync(bundledNodePath, targetNodeFile);
-			} catch {
-				console.error("Failed to copy bundled Node runtime.");
-
-				return "";
-			}
-
-			return `${exeName}:${targetNodeFile}`;
+		const fallbackNodePath = join(homedir(), ".ytDownloader", nodeName);
+		if (existsSync(fallbackNodePath)) {
+			return `${exeName}:${fallbackNodePath}`;
 		}
 
 		return "";

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,3 +82,267 @@ export function formatTime(duration) {
 	return `${pad(mins)}:${pad(secs)}`;
 }
 
+/**
+ * Locates the ffmpeg directory path (containing bin/ffmpeg and bin/ffprobe).
+ * @returns {Promise<string>}
+ */
+export async function findFfmpeg() {
+	const { env, platform, execSync, __dirname, windowsStore, homedir, fs, join, dirname } = window.electronAPI;
+	const existsSync = fs.existsSync;
+	const cpSync = fs.cpSync;
+
+	// Priority 1: Environment Variable
+	if (env && env.YTDOWNLOADER_FFMPEG_PATH) {
+		if (existsSync(env.YTDOWNLOADER_FFMPEG_PATH)) {
+			return env.YTDOWNLOADER_FFMPEG_PATH;
+		}
+		throw new Error(
+			"YTDOWNLOADER_FFMPEG_PATH is set, but no file exists there.",
+		);
+	}
+
+	// Priority 2: System-installed (FreeBSD)
+	if (platform() === "freebsd") {
+		try {
+			return execSync("which ffmpeg").toString().trim();
+		} catch {
+			throw new Error(
+				"No ffmpeg found in PATH on FreeBSD. App may not work correctly.",
+			);
+		}
+	}
+
+	// Priority 2.5: User-selected system ffmpeg
+	const ffmpegSource = localStorage.getItem("ffmpegSource") || "bundled";
+	if (ffmpegSource === "system") {
+		try {
+			let sysPath;
+			if (platform() === "win32") {
+				sysPath = execSync("where ffmpeg")
+					.toString()
+					.split(/\r?\n/)[0]
+					.trim();
+			} else {
+				sysPath = execSync("command -v ffmpeg || which ffmpeg")
+					.toString()
+					.split(/\r?\n/)[0]
+					.trim();
+			}
+			if (sysPath && existsSync(sysPath)) {
+				return dirname(sysPath);
+			}
+		} catch {
+			console.warn(
+				"System ffmpeg not found in PATH; falling back to bundled.",
+			);
+		}
+	}
+
+	// Priority 3: Bundled ffmpeg
+	const bundledDir = join(__dirname, "..", "ffmpeg");
+	const isWin = platform() === "win32";
+	const ffmpegName = isWin ? "ffmpeg.exe" : "ffmpeg";
+	const bundledFfmpegFile = join(bundledDir, "bin", ffmpegName);
+
+	// MS Store packages run in a restricted WindowsApps container where executing binaries fails
+	if (windowsStore) {
+		const targetDir = join(homedir(), ".ytDownloader", "ffmpeg");
+		const targetFfmpegFile = join(targetDir, "bin", ffmpegName);
+
+		if (!existsSync(targetFfmpegFile)) {
+			if (existsSync(bundledDir)) {
+				try {
+					cpSync(bundledDir, targetDir, {
+						recursive: true,
+						dereference: true,
+					});
+				} catch {
+					console.error("Failed to copy bundled ffmpeg.");
+					return "";
+				}
+			} else {
+				return "";
+			}
+		}
+
+		return join(targetDir, "bin");
+	}
+
+	if (existsSync(bundledFfmpegFile)) {
+		return join(bundledDir, "bin");
+	}
+
+	// Fallback if existing copy is present in ~/.ytDownloader
+	const fallbackDir = join(homedir(), ".ytDownloader", "ffmpeg", "bin");
+	if (existsSync(join(fallbackDir, ffmpegName))) {
+		return fallbackDir;
+	}
+
+	return "";
+}
+
+/**
+ * Ensures shared libraries are loadable on Linux by setting LD_LIBRARY_PATH
+ * @param {string} ffmpegPath
+ */
+export function ensureFfmpegLibsLoadable(ffmpegPath) {
+	const { env, platform, join, fs, setEnv } = window.electronAPI;
+	if (platform() !== "linux" || !ffmpegPath) {
+		return;
+	}
+
+	const libDir = join(ffmpegPath, "..", "lib");
+	if (!fs.existsSync(libDir)) {
+		return;
+	}
+
+	const current = env ? env.LD_LIBRARY_PATH : undefined;
+	if (current) {
+		if (!current.split(":").includes(libDir)) {
+			setEnv("LD_LIBRARY_PATH", `${libDir}:${current}`);
+		}
+	} else {
+		setEnv("LD_LIBRARY_PATH", libDir);
+	}
+}
+
+/**
+ * Returns full path to the ffmpeg executable.
+ * @returns {string}
+ */
+export function getFfmpegPath() {
+	const isTestMode = Boolean(window.electronAPI && window.electronAPI.isTest);
+	if (isTestMode && (window.__mockYtDlp || window.__mockSpawn || window.__mockFfmpeg)) return "ffmpeg";
+
+	const { env, fs, path, os } = window.electronAPI;
+	if (
+		env &&
+		env.YTDOWNLOADER_FFMPEG_PATH &&
+		fs.existsSync(env.YTDOWNLOADER_FFMPEG_PATH)
+	) {
+		return env.YTDOWNLOADER_FFMPEG_PATH;
+	}
+
+	const dir = window.AppBinaries?.ffmpegPath;
+	if (!dir) return "";
+	const ext = os.platform() === "win32" ? ".exe" : "";
+	return path.join(dir, "ffmpeg" + ext);
+}
+
+/**
+ * Returns full path to the ffprobe executable.
+ * @returns {string}
+ */
+export function getFfprobePath() {
+	const isTestMode = Boolean(window.electronAPI && window.electronAPI.isTest);
+	if (isTestMode && (window.__mockYtDlp || window.__mockSpawn || window.__mockFfmpeg)) return "ffprobe";
+
+	const { env, fs, path, os } = window.electronAPI;
+	if (
+		env &&
+		env.YTDOWNLOADER_FFMPEG_PATH &&
+		fs.existsSync(env.YTDOWNLOADER_FFMPEG_PATH)
+	) {
+		const dir = path.dirname(env.YTDOWNLOADER_FFMPEG_PATH);
+		const ext = os.platform() === "win32" ? ".exe" : "";
+		return path.join(dir, "ffprobe" + ext);
+	}
+
+	const dir = window.AppBinaries?.ffmpegPath;
+	if (!dir) return "";
+	const ext = os.platform() === "win32" ? ".exe" : "";
+	return path.join(dir, "ffprobe" + ext);
+}
+
+/**
+ * Determines the JavaScript runtime path for yt-dlp.
+ * @returns {Promise<string>}
+ */
+export async function getJsRuntimePath() {
+	const { env, platform, __dirname, windowsStore, homedir, fs, join } = window.electronAPI;
+	const existsSync = fs.existsSync;
+	const copyFileSync = fs.copyFileSync;
+	const mkdirSync = fs.mkdirSync;
+	const exeName = "node";
+
+	// Priority 1: Environment Variable (Node)
+	if (env && env.YTDOWNLOADER_NODE_PATH) {
+		if (existsSync(env.YTDOWNLOADER_NODE_PATH)) {
+			return `$node:${env.YTDOWNLOADER_NODE_PATH}`;
+		}
+
+		return "";
+	}
+
+	// Priority 2: Environment Variable (Deno)
+	if (env && env.YTDOWNLOADER_DENO_PATH) {
+		if (existsSync(env.YTDOWNLOADER_DENO_PATH)) {
+			return `$deno:${env.YTDOWNLOADER_DENO_PATH}`;
+		}
+
+		return "";
+	}
+
+	// Priority 3: System-installed Deno (macOS Fallback)
+	if (platform() === "darwin") {
+		const possiblePaths = [
+			"/opt/homebrew/bin/deno",
+			"/usr/local/bin/deno",
+		];
+
+		for (const p of possiblePaths) {
+			if (existsSync(p)) {
+				return `deno:${p}`;
+			}
+		}
+
+		console.log("No Deno installation found");
+
+		return "";
+	}
+
+	// Priority 4: Bundled Node Runtime
+	const isWin = platform() === "win32";
+	const nodeName = isWin ? "node.exe" : "node";
+
+	const bundledNodePath = join(__dirname, "..", nodeName);
+
+	// MS Store packages run in a restricted WindowsApps container
+	if (windowsStore) {
+		const targetDir = join(homedir(), ".ytDownloader");
+		const targetNodeFile = join(targetDir, nodeName);
+
+		if (existsSync(targetNodeFile)) {
+			return `${exeName}:${targetNodeFile}`;
+		}
+
+		if (existsSync(bundledNodePath)) {
+			if (!existsSync(targetDir)) {
+				mkdirSync(targetDir, {recursive: true});
+			}
+
+			try {
+				copyFileSync(bundledNodePath, targetNodeFile);
+			} catch {
+				console.error("Failed to copy bundled Node runtime.");
+				return "";
+			}
+
+			return `${exeName}:${targetNodeFile}`;
+		}
+
+		return "";
+	}
+
+	if (existsSync(bundledNodePath)) {
+		return `${exeName}:${bundledNodePath}`;
+	}
+
+	const fallbackNodePath = join(homedir(), ".ytDownloader", nodeName);
+	if (existsSync(fallbackNodePath)) {
+		return `${exeName}:${fallbackNodePath}`;
+	}
+
+	return "";
+}
+

--- a/src/utils.js
+++ b/src/utils.js
@@ -101,18 +101,7 @@ export async function findFfmpeg() {
 		);
 	}
 
-	// Priority 2: System-installed (FreeBSD)
-	if (platform() === "freebsd") {
-		try {
-			return execSync("which ffmpeg").toString().trim();
-		} catch {
-			throw new Error(
-				"No ffmpeg found in PATH on FreeBSD. App may not work correctly.",
-			);
-		}
-	}
-
-	// Priority 2.5: User-selected system ffmpeg
+	// Priority 2: User-selected system ffmpeg
 	const ffmpegSource = localStorage.getItem("ffmpegSource") || "bundled";
 	if (ffmpegSource === "system") {
 		try {


### PR DESCRIPTION
## Summary
- Restrict copying bundled FFmpeg (~86 MB) and Node.js (~87 MB) to \~/.ytDownloader\ exclusively for Windows Store (\windowsStore === true\) builds where AppContainer / WindowsApps ACLs prevent in-place execution.
- For all standard builds (dev, NSIS installer, MSI, Portable Zip, Linux, macOS), execute directly from the bundled application directory, eliminating startup blocking and redundant ~173 MB disk duplication.
- Harmonize FFmpeg and Node runtime path resolution across \enderer.js\, \playlist.js\, \compressor.js\, and \preferences.js\.