### PR TITLE
Fix execsync

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -349,7 +349,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	spawn: spawnWrapper,
 	spawnSync: (command, args, options) => spawnSync(command, args, options),
 	exec: (command, options, callback) => exec(command, options, callback),
-	execSync: (command, options) => execSync(command, options),
+	execSync: (command, options) => execSync(command, { encoding: "utf-8", ...options }),
 	si: {
 		graphics: () => si.graphics(),
 	},

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -266,15 +266,16 @@ class YtDownloaderApp {
 						CONSTANTS.LOCAL_STORAGE_KEYS.YT_DLP_PATH,
 					);
 				}
-
 				const ytDlpPath = mockYtDlp
 					? "mock-ytdlp"
 					: await this._findOrDownloadYtDlp();
 				const ytDlp = mockYtDlp || YTDlpWrap.new(ytDlpPath);
+
 				const ffmpegPath = mockYtDlp
 					? "ffmpeg"
 					: await findFfmpeg();
 				ensureFfmpegLibsLoadable(ffmpegPath);
+
 				const jsRuntimePath = mockYtDlp
 					? ""
 					: await getJsRuntimePath();


### PR DESCRIPTION
----
## Summary by Gitar

- **Execsync implementation:**
    - Updated `execSync` in `preload.js` to default to `utf-8` encoding.

<sub>This will update automatically on new commits.</sub>