### PR TITLE
Make video codecs more user friendly

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1207,10 +1207,10 @@
                             <div class="prefBox">
                                 <span id="preferredVideoCodecTxt" data-translate="preferredVideoCodec">Preferred video codec</span>
                                 <select id="preferredVideoCodec">
-                                    <option value="avc1">AVC1</option>
+                                    <option value="avc1">H.264 (AVC)</option>
                                     <option value="av01">AV1</option>
                                     <option value="vp9">VP9</option>
-                                    <option value="mp4v">MP4V</option>
+                                    <option value="mp4v">MPEG-4</option>
                                 </select>
                             </div>
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -2,6 +2,7 @@ import {
 	getId as $,
 	showPopup,
 	formatTime,
+	formatVideoCodec,
 	findFfmpeg,
 	ensureFfmpegLibsLoadable,
 	getJsRuntimePath,
@@ -2398,7 +2399,7 @@ class YtDownloaderApp {
 				}
 
 				const quality = `${format.height || "???"}p${format.fps === 60 ? "60" : ""}`;
-				const vcodecText = format.vcodec?.split(".")[0] || "";
+				const vcodecText = formatVideoCodec(format.vcodec);
 
 				let audioMarkup = `<div class="audio-placeholder"></div>`;
 				if (hasAudio) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -335,3 +335,21 @@ export async function getJsRuntimePath() {
 	return "";
 }
 
+/**
+ * Maps raw video codec strings (e.g. avc1, av01, vp9) into user-friendly display names (e.g. H.264, AV1, VP9)
+ * @param {string | null | undefined} codec
+ * @returns {string}
+ */
+export function formatVideoCodec(codec) {
+	if (!codec || codec === "none") return "";
+	const lower = codec.toLowerCase();
+	if (lower.startsWith("avc1") || lower.startsWith("avc") || lower.startsWith("h264")) return "H.264";
+	if (lower.startsWith("av01") || lower.startsWith("av1")) return "AV1";
+	if (lower.startsWith("vp9") || lower.startsWith("vp09")) return "VP9";
+	if (lower.startsWith("vp8") || lower.startsWith("vp08")) return "VP8";
+	if (lower.startsWith("hev1") || lower.startsWith("hvc1") || lower.startsWith("hevc") || lower.startsWith("h265")) return "H.265";
+	if (lower.startsWith("mp4v")) return "MPEG-4";
+	if (lower.startsWith("prores")) return "ProRes";
+	if (lower.startsWith("theora")) return "Theora";
+	return codec.split(".")[0];
+}

--- a/tests/format-video-codec.spec.js
+++ b/tests/format-video-codec.spec.js
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+import { formatVideoCodec } from "../src/utils.js";
+
+test.describe("formatVideoCodec", () => {
+	test("maps AVC/H.264 codecs properly", () => {
+		expect(formatVideoCodec("avc1.640028")).toBe("H.264");
+		expect(formatVideoCodec("avc1.4d401f")).toBe("H.264");
+		expect(formatVideoCodec("avc3.640028")).toBe("H.264");
+		expect(formatVideoCodec("h264")).toBe("H.264");
+	});
+
+	test("maps AV1 codecs properly", () => {
+		expect(formatVideoCodec("av01.0.08M.08")).toBe("AV1");
+		expect(formatVideoCodec("av1")).toBe("AV1");
+	});
+
+	test("maps VP9 and VP8 codecs properly", () => {
+		expect(formatVideoCodec("vp9")).toBe("VP9");
+		expect(formatVideoCodec("vp09.00.51.08.01.01.01.01.00")).toBe("VP9");
+		expect(formatVideoCodec("vp8")).toBe("VP8");
+		expect(formatVideoCodec("vp08")).toBe("VP8");
+	});
+
+	test("maps HEVC/H.265 codecs properly", () => {
+		expect(formatVideoCodec("hev1.1.6.L93.B0")).toBe("H.265");
+		expect(formatVideoCodec("hvc1.1.6.L93.B0")).toBe("H.265");
+		expect(formatVideoCodec("hevc")).toBe("H.265");
+		expect(formatVideoCodec("h265")).toBe("H.265");
+	});
+
+	test("maps MPEG-4, ProRes, Theora and other codecs properly", () => {
+		expect(formatVideoCodec("mp4v.20.3")).toBe("MPEG-4");
+		expect(formatVideoCodec("prores")).toBe("ProRes");
+		expect(formatVideoCodec("theora")).toBe("Theora");
+	});
+
+	test("handles edge cases (null, empty, none, unknown)", () => {
+		expect(formatVideoCodec(null)).toBe("");
+		expect(formatVideoCodec(undefined)).toBe("");
+		expect(formatVideoCodec("")).toBe("");
+		expect(formatVideoCodec("none")).toBe("");
+		expect(formatVideoCodec("custom_codec.123")).toBe("custom_codec");
+	});
+});


### PR DESCRIPTION
----
## Summary by Gitar

- **Codec Formatting:**
    - Added `formatVideoCodec` utility in `src/utils.js` to map raw codecs to user-friendly names
    - Updated UI dropdown options in `html/index.html` and video stream display in `src/renderer.js`
    - Added comprehensive unit tests in `tests/format-video-codec.spec.js`

<sub>This will update automatically on new commits.</sub>