### PR TITLE
Preferred video quality adjustments

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -627,14 +627,14 @@
                                     </div>
                                     <div class="playlist-select-wrapper">
                                         <select id="select" class="select playlist-select">
-                                            <option value="best" id="bestVideoOption" data-translate="best" selected>Best</option>
+                                            <option value="best" id="bestVideoOption" data-translate="best">Best</option>
                                             <option value="worst" id="worstVideoOption" data-translate="qualityWorst">Worst</option>
                                             <option value="144">144p</option>
                                             <option value="240">240p</option>
                                             <option value="360">360p</option>
                                             <option value="480">480p</option>
                                             <option value="720">720p (HD)</option>
-                                            <option value="1080">1080p (FHD)</option>
+                                            <option value="1080" selected>1080p (FHD)</option>
                                             <option value="1440">1440p</option>
                                             <option value="2160">2160p (4k)</option>
                                         </select>
@@ -1227,7 +1227,7 @@
                                     <option value="360">360p</option>
                                     <option value="480">480p</option>
                                     <option value="720">720p (HD)</option>
-                                    <option value="1080">1080p (FHD)</option>
+                                    <option value="1080" selected>1080p (FHD)</option>
                                     <option value="1440">1440p</option>
                                     <option value="2160">2160p (4k)</option>
                                 </select>

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -218,13 +218,15 @@ const playlistDownloader = {
 			localStorage.setItem("downloadPath", defaultDownloadsDir);
 		}
 
-		const preferredVideo = localStorage.getItem("preferredVideoQuality");
-		if (preferredVideo && this.ui.videoQualitySelect) {
+		const preferredVideo =
+			localStorage.getItem("preferredVideoQuality") || "1080";
+		if (this.ui.videoQualitySelect) {
 			this.ui.videoQualitySelect.value = preferredVideo;
 		}
 		if (this.ui.videoQualitySelect && !this.ui.videoQualitySelect.value) {
-			this.ui.videoQualitySelect.value = "best";
+			this.ui.videoQualitySelect.value = "1080";
 		}
+		this.updateVideoTypeVisibility();
 
 		const preferredAudioFormat = localStorage.getItem("preferredAudioQuality");
 		if (preferredAudioFormat && this.ui.audioTypeSelect) {

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -531,18 +531,22 @@ function initPreferences() {
 		}
 	}
 
-	function bindSelectToStorage(elementId, storageKey) {
+	function bindSelectToStorage(elementId, storageKey, defaultValue) {
 		const el = getId(elementId);
 		if (!el) return;
 		const value = localStorage.getItem(storageKey);
-		if (value) el.value = value;
+		if (value) {
+			el.value = value;
+		} else if (defaultValue) {
+			el.value = defaultValue;
+		}
 
 		const updateVal = (e) => localStorage.setItem(storageKey, e.target.value);
 		el.addEventListener("change", updateVal);
 		el.addEventListener("input", updateVal);
 	}
 
-	bindSelectToStorage("preferredVideoQuality", "preferredVideoQuality");
+	bindSelectToStorage("preferredVideoQuality", "preferredVideoQuality", "1080");
 	bindSelectToStorage("preferredAudioQuality", "preferredAudioQuality");
 	bindSelectToStorage("preferredVideoCodec", "preferredVideoCodec");
 

--- a/tests/playlist-preferences-integration.spec.js
+++ b/tests/playlist-preferences-integration.spec.js
@@ -76,6 +76,18 @@ test.describe("Playlist Preferences Integration Tests", () => {
 		expect(downloadCmd[oIndex + 1]).toBe(expectedOutputPath);
 	});
 
+	test("default preferred video quality in playlist is 1080", async () => {
+		const res = await launchApp();
+
+		electronApp = res.app;
+		page = res.page;
+		await page.waitForFunction(() => typeof window.switchView === "function");
+		await page.click("#playlistWin");
+
+		const selectedVideo = await page.$eval("#select", (el) => el.value);
+		expect(selectedVideo).toBe("1080");
+	});
+
 	test("preferred video and audio quality defaults are selected in UI dropdowns", async () => {
 		const res = await launchApp({
 			preferredVideoQuality: "720",

--- a/tests/preferences-page.spec.js
+++ b/tests/preferences-page.spec.js
@@ -124,9 +124,12 @@ test.describe("Preferences Page Tests", () => {
 	test("media settings preferences save to localStorage", async () => {
 		await page.click('button[data-tab="media"]');
 
-		await page.selectOption("#preferredVideoQuality", "1080");
+		const defaultVideoQuality = await page.$eval("#preferredVideoQuality", (el) => el.value);
+		expect(defaultVideoQuality).toBe("1080");
+
+		await page.selectOption("#preferredVideoQuality", "720");
 		const videoQuality = await page.evaluate(() => localStorage.getItem("preferredVideoQuality"));
-		expect(videoQuality).toBe("1080");
+		expect(videoQuality).toBe("720");
 
 		await page.selectOption("#preferredVideoCodec", "vp9");
 		const videoCodec = await page.evaluate(() => localStorage.getItem("preferredVideoCodec"));


### PR DESCRIPTION
----
## Summary by Gitar

- **Preferences & Quality Defaults:**
    - Set default preferred video quality to `1080` instead of `best` across storage bindings and UI dropdowns
    - Updated HTML video quality selections and added integration/page tests for the new default quality

<sub>This will update automatically on new commits.</sub>