### PR TITLE
Add support to change UI zoom

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1200,6 +1200,26 @@
 
                         <section class="settings-section">
                             <div class="prefBox">
+                                <div class="pref-label-group">
+                                    <span id="zoomLevelTxt" data-translate="zoomLevel">UI Zoom</span>
+                                    <p class="pref-subtitle" data-translate="zoomLevelSubtitle">Adjust the interface scale</p>
+                                </div>
+                                <select id="zoomLevelSelect">
+                                    <option value="0.75">75%</option>
+                                    <option value="0.8">80%</option>
+                                    <option value="0.9">90%</option>
+                                    <option value="1" selected>100%</option>
+                                    <option value="1.1">110%</option>
+                                    <option value="1.25">125%</option>
+                                    <option value="1.5">150%</option>
+                                    <option value="1.75">175%</option>
+                                    <option value="2">200%</option>
+                                </select>
+                            </div>
+                        </section>
+
+                        <section class="settings-section">
+                            <div class="prefBox">
                                 <span id="maxTxt" data-translate="maxActiveDownloads">Maximum number of active downloads</span>
                                 <input type="number" min="1" class="input input-num" id="maxDownloads" value="5">
                             </div>

--- a/main.js
+++ b/main.js
@@ -106,8 +106,8 @@ function createWindow() {
 
 	appState.mainWindow = new BrowserWindow({
 		...bounds,
-		minWidth: 800,
-		minHeight: 600,
+		minWidth: 680,
+		minHeight: 500,
 		autoHideMenuBar: true,
 		show: false,
 		icon: path.join(__dirname, "/assets/images/icon.png"),
@@ -176,8 +176,10 @@ function createSecondaryWindow(file) {
 			sandbox: false,
 			preload: path.join(__dirname, "preload.js"),
 		},
-		width: 1000,
-		height: 800,
+		width: 900,
+		height: 640,
+		minWidth: 680,
+		minHeight: 500,
 	});
 
 	// appState.secondaryWindow.webContents.openDevTools();
@@ -782,7 +784,7 @@ async function loadConfiguration() {
 			error.message,
 		);
 		appState.config = {
-			bounds: { width: 1024, height: 768 },
+			bounds: { width: 900, height: 640 },
 			isMaximized: false,
 		};
 	}

--- a/preload.js
+++ b/preload.js
@@ -1,4 +1,4 @@
-const { contextBridge, ipcRenderer, shell, clipboard } = require("electron");
+const { contextBridge, ipcRenderer, shell, clipboard, webFrame } = require("electron");
 const path = require("path");
 const os = require("os");
 const fs = require("fs");
@@ -427,4 +427,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	isTest: process.env.NODE_ENV === "test" || process.argv.includes("--is-test") || process.env.YTDOWNLOADER_TEST === "true",
 	windowsStore: process.windowsStore,
 	__dirname: path.join(__dirname, "html"),
+	webFrame: {
+		setZoomFactor: (factor) => webFrame.setZoomFactor(factor),
+		getZoomFactor: () => webFrame.getZoomFactor(),
+	},
 });

--- a/src/common.js
+++ b/src/common.js
@@ -158,10 +158,55 @@ function initTheme() {
 	}
 }
 
+export function applyZoom(zoom) {
+	const factor = parseFloat(zoom) || 1;
+	if (window.electronAPI?.webFrame?.setZoomFactor) {
+		window.electronAPI.webFrame.setZoomFactor(factor);
+	}
+	const zoomSelect = getId("zoomLevelSelect");
+	if (zoomSelect && zoomSelect.value !== String(zoom)) {
+		zoomSelect.value = String(zoom);
+	}
+}
+window.applyZoom = applyZoom;
+
+export function initZoom() {
+	const savedZoom = localStorage.getItem("zoomLevel") || "1";
+	applyZoom(savedZoom);
+}
+window.initZoom = initZoom;
+
+const ZOOM_STEPS = [0.75, 0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2];
+
+window.addEventListener("keydown", (e) => {
+	if (!e.ctrlKey && !e.metaKey) return;
+	if (e.key === "=" || e.key === "+") {
+		e.preventDefault();
+		const current = parseFloat(localStorage.getItem("zoomLevel") || "1");
+		const next = ZOOM_STEPS.find((s) => s > current + 0.01) ?? 2;
+		localStorage.setItem("zoomLevel", String(next));
+		applyZoom(next);
+	} else if (e.key === "-") {
+		e.preventDefault();
+		const current = parseFloat(localStorage.getItem("zoomLevel") || "1");
+		const prev = [...ZOOM_STEPS].reverse().find((s) => s < current - 0.01) ?? 0.75;
+		localStorage.setItem("zoomLevel", String(prev));
+		applyZoom(prev);
+	} else if (e.key === "0") {
+		e.preventDefault();
+		localStorage.setItem("zoomLevel", "1");
+		applyZoom(1);
+	}
+});
+
 if (document.readyState === "loading") {
-	document.addEventListener("DOMContentLoaded", initTheme);
+	document.addEventListener("DOMContentLoaded", () => {
+		initTheme();
+		initZoom();
+	});
 } else {
 	initTheme();
+	initZoom();
 }
 
 ////

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -837,6 +837,24 @@ function initPreferences() {
 		maxDownloadsInput.addEventListener("change", updateMax);
 	}
 
+	// Zoom Level Selector
+	const zoomLevelSelect = getId("zoomLevelSelect");
+	if (zoomLevelSelect) {
+		const savedZoom = localStorage.getItem("zoomLevel") || "1";
+		zoomLevelSelect.value = savedZoom;
+		const updateZoom = () => {
+			const val = zoomLevelSelect.value;
+			localStorage.setItem("zoomLevel", val);
+			if (window.applyZoom) {
+				window.applyZoom(val);
+			} else if (window.electronAPI?.webFrame?.setZoomFactor) {
+				window.electronAPI.webFrame.setZoomFactor(parseFloat(val) || 1);
+			}
+		};
+		zoomLevelSelect.addEventListener("change", updateZoom);
+		zoomLevelSelect.addEventListener("input", updateZoom);
+	}
+
 	// UI Switches triggers
 	function bindCheckboxToStorage(
 		checkboxId,

--- a/tests/preferences-page.spec.js
+++ b/tests/preferences-page.spec.js
@@ -123,6 +123,14 @@ test.describe("Preferences Page Tests", () => {
 		await page.selectOption("#updateChannelSelect", "beta");
 		const savedChannel = await page.evaluate(() => localStorage.getItem("updateChannel"));
 		expect(savedChannel).toBe("beta");
+
+		await page.selectOption("#zoomLevelSelect", "0.8");
+		const savedZoom = await page.evaluate(() => localStorage.getItem("zoomLevel"));
+		expect(savedZoom).toBe("0.8");
+		const zoomFactor = await page.evaluate(() => window.electronAPI?.webFrame?.getZoomFactor?.());
+		if (zoomFactor !== undefined) {
+			expect(zoomFactor).toBeCloseTo(0.8);
+		}
 	});
 
 	test("media settings preferences save to localStorage", async () => {

--- a/translations/en.json
+++ b/translations/en.json
@@ -15,6 +15,8 @@
 	"start": "Start",
 	"selectLanguageRelaunch": "Select Language",
 	"selectLanguage": "Select Language",
+	"zoomLevel": "UI Zoom",
+	"zoomLevelSubtitle": "Adjust the interface scale",
 	"downloadTimeRange": "Download particular time-range",
 	"end": "End",
 	"timeRangeStartEmptyHint": "If kept empty, it will start from the beginning",


### PR DESCRIPTION
----
## Summary by Gitar

- **UI Scaling & Zoom Support:**
    - Added `applyZoom` and `initZoom` functions in `src/common.js` with shortcut key bindings.
    - Added a `zoomLevelSelect` UI preference element in `html/index.html` and configured its logic in `src/preferences.js`.
    - Exposed `webFrame` APIs via `preload.js` and added English translation strings in `translations/en.json`.
- **Window Configuration & Tests:**
    - Updated minimum dimensions and default window bounds in `main.js`.
    - Added test coverage for zoom level preferences in `tests/preferences-page.spec.js`.

<sub>This will update automatically on new commits.</sub>