### PR TITLE
Hide unavailable vids in playlist selective download

### DIFF
--- a/src/playlist.js
+++ b/src/playlist.js
@@ -540,6 +540,8 @@ const playlistDownloader = {
 			"--flat-playlist",
 			"-J",
 			"--no-warnings",
+			"--compat-options",
+			"no-youtube-unavailable-videos",
 			...(this.config.cookie.arg && this.config.cookie.val
 				? [this.config.cookie.arg, this.config.cookie.val]
 				: []),


### PR DESCRIPTION
----
## Summary by Gitar

- **Playlist downloader:**
    - Added `--compat-options no-youtube-unavailable-videos` to hide unavailable videos in playlist selective download

<sub>This will update automatically on new commits.</sub>