### PR TITLE
Fix preset being overridden by preferred format in auto download

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1342,18 +1342,6 @@ class YtDownloaderApp {
 				this._updateHomePathDisplay();
 			}
 		}
-
-		// Sync quick preset defaults from preferences
-		const qualitySelect = document.getElementById("presetQualitySelect");
-		if (qualitySelect && prefs.videoQuality) {
-			const matchingOpt = Array.from(qualitySelect.options).find(
-				(opt) => opt.value === String(prefs.videoQuality),
-			);
-			if (matchingOpt) {
-				qualitySelect.value = String(prefs.videoQuality);
-				this.state.batchPreset.quality = String(prefs.videoQuality);
-			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
----
## Summary by Gitar

- **Bug fixes:**
    - Removed override logic in `renderer.js` to prevent presets from being overwritten by preferred format during auto download.

<sub>This will update automatically on new commits.</sub>