### PR TITLE
Update package description for NSIS installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"private": false
 	},
 	"license": "GPL-3.0",
-	"description": "Download videos and audios from YouTube and many other sites",
+	"description": "YTDownloader installer",
 	"devDependencies": {
 		"@playwright/test": "^1.45.0",
 		"electron": "^30.5.1",
@@ -120,6 +120,7 @@
 			"allowToChangeInstallationDirectory": true,
 			"oneClick": false,
 			"deleteAppDataOnUninstall": true,
+			"uninstallDisplayName": "YTDownloader",
 			"license": "./LICENSE.rtf"
 		},
 		"msi": {


### PR DESCRIPTION
@aandrew-me 

Changes to fix

<img width="405" height="561" alt="image" src="https://github.com/user-attachments/assets/3c146743-1c44-4ac7-a62c-e26abc1de423" />

File description should be "YTDownloader installer".

<img width="1031" height="267" alt="image" src="https://github.com/user-attachments/assets/9ef0e979-87f4-4293-a676-38f23cb3e156" />

In the program name list is included also program version.
But version is already available in Version.
As program name just be program name.
